### PR TITLE
refactor: use generics for message broker components

### DIFF
--- a/crates/message_broker/src/lib.rs
+++ b/crates/message_broker/src/lib.rs
@@ -3,21 +3,48 @@ pub mod quests_channel;
 pub mod redis;
 
 use events_queue::RedisEventsQueue;
-use quests_channel::RedisQuestsChannel;
+use quests_channel::{RedisQuestsChannelPublisher, RedisQuestsChannelSubscriber};
 use redis::Redis;
 use std::sync::Arc;
 
-pub async fn init_message_broker_components(
+pub async fn init_message_broker_components_with_subscriber<F>(
     redis_url: &str,
-) -> (RedisEventsQueue, RedisQuestsChannel) {
-    log::info!("Redis URL: {}", &redis_url);
-    let redis = Redis::new(redis_url).await.expect("Can connect to Redis");
-    let redis = Arc::new(redis);
+) -> (RedisEventsQueue, RedisQuestsChannelSubscriber<F>) {
+    let redis = init_redis(redis_url).await;
 
     let redis_events_queue = RedisEventsQueue::new(redis.clone());
-    let quests_channel = RedisQuestsChannel::new(redis.clone()).await;
-
-    quests_channel.listen(redis);
+    let quests_channel = init_quests_channel_subscriber(redis);
 
     (redis_events_queue, quests_channel)
+}
+
+pub async fn init_message_broker_components_with_publisher(
+    redis_url: &str,
+) -> (RedisEventsQueue, RedisQuestsChannelPublisher) {
+    let redis = init_redis(redis_url).await;
+
+    let redis_events_queue = init_events_queue(redis.clone());
+    let quests_channel = init_quests_channel_publisher(redis).await;
+
+    (redis_events_queue, quests_channel)
+}
+
+async fn init_redis(redis_url: &str) -> Arc<Redis> {
+    log::info!("Redis URL: {}", &redis_url);
+    let redis = Redis::new(redis_url).await.expect("Can connect to Redis");
+    Arc::new(redis)
+}
+
+fn init_events_queue(redis: Arc<Redis>) -> RedisEventsQueue {
+    RedisEventsQueue::new(redis)
+}
+
+fn init_quests_channel_subscriber<SubscriptionNotifier>(
+    redis: Arc<Redis>,
+) -> RedisQuestsChannelSubscriber<SubscriptionNotifier> {
+    RedisQuestsChannelSubscriber::new(redis)
+}
+
+async fn init_quests_channel_publisher(redis: Arc<Redis>) -> RedisQuestsChannelPublisher {
+    RedisQuestsChannelPublisher::new(redis).await
 }

--- a/crates/server/src/components.rs
+++ b/crates/server/src/components.rs
@@ -1,11 +1,18 @@
 use crate::configuration::Config;
+use dcl_rpc::stream_protocol::GeneratorYielder;
 use quests_db::{create_quests_db_component, Database};
+use quests_definitions::quests::UserUpdate;
 use quests_message_broker::{
-    events_queue::RedisEventsQueue, init_message_broker_components,
-    quests_channel::RedisQuestsChannel,
+    events_queue::RedisEventsQueue, init_message_broker_components_with_subscriber,
+    quests_channel::RedisQuestsChannelSubscriber,
 };
 
-pub async fn init_components() -> (Config, Database, RedisEventsQueue, RedisQuestsChannel) {
+pub async fn init_components() -> (
+    Config,
+    Database,
+    RedisEventsQueue,
+    RedisQuestsChannelSubscriber<GeneratorYielder<UserUpdate>>,
+) {
     let config = Config::new().expect("Unable to build up the config");
 
     log::debug!("Configuration: {config:?}");
@@ -14,7 +21,15 @@ pub async fn init_components() -> (Config, Database, RedisEventsQueue, RedisQues
         .await
         .expect("unable to run the migrations"); // we know that the migrations failed because if connection fails, the app panics
 
-    let (events_queue, quests_channel) = init_message_broker_components(&config.redis_url).await;
+    let (events_queue, quests_channel) = init_message_broker_components_with_subscriber::<
+        GeneratorYielder<UserUpdate>,
+    >(&config.redis_url)
+    .await;
+
+    quests_channel.listen(|notifier, users_update| {
+        let yielder = notifier.clone();
+        async move { yielder.r#yield(users_update).await.unwrap() }
+    });
 
     (config, quests_database, events_queue, quests_channel)
 }

--- a/crates/server/src/domain/events.rs
+++ b/crates/server/src/domain/events.rs
@@ -3,7 +3,7 @@ use quests_message_broker::events_queue::{EventsQueue, EventsQueueResult};
 use std::sync::Arc;
 
 pub async fn add_event_controller(
-    events_queue: Arc<impl EventsQueue>,
+    events_queue: Arc<impl EventsQueue<Event>>,
     event: Event,
 ) -> EventsQueueResult<usize> {
     if event.action.is_some() {

--- a/crates/server/src/rpc/service.rs
+++ b/crates/server/src/rpc/service.rs
@@ -12,7 +12,7 @@ use quests_definitions::quests::{
     QuestStateUpdate, QuestsServiceServer, ServerStreamResponse, StartQuestRequest,
     StartQuestResponse, UserAddress, UserUpdate,
 };
-use quests_message_broker::quests_channel::QuestsChannel;
+use quests_message_broker::quests_channel::QuestsChannelSubscriber;
 use std::sync::Arc;
 
 use super::QuestsRpcServerContext;
@@ -115,19 +115,8 @@ impl QuestsServiceServer<QuestsRpcServerContext> for QuestsServiceImplementation
                 for instance in instances {
                     let yielder = generator_yielder.clone();
 
-                    ctx.redis_quests_channel
-                        .subscribe(
-                            &instance.id,
-                            // TODO: change this. remove the box
-                            Box::new(move |user_update| {
-                                // TODO: fix this
-                                let yielder = yielder.clone();
-                                Box::pin(async move {
-                                    yielder.r#yield(user_update).await.unwrap();
-                                    // TODO: handle error
-                                })
-                            }),
-                        )
+                    ctx.redis_quests_channel_subscriber
+                        .subscribe(&instance.id, yielder)
                         .await;
                 }
 

--- a/crates/server/src/rpc/service.rs
+++ b/crates/server/src/rpc/service.rs
@@ -1,3 +1,4 @@
+use super::QuestsRpcServerContext;
 use crate::{
     api::routes::quests::StartQuestRequest as StartQuestRequestAPI,
     domain::{
@@ -15,7 +16,6 @@ use quests_definitions::quests::{
 use quests_message_broker::quests_channel::QuestsChannelSubscriber;
 use std::sync::Arc;
 
-use super::QuestsRpcServerContext;
 pub struct QuestsServiceImplementation {}
 
 #[async_trait::async_trait]

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -4,9 +4,11 @@ use actix_web::body::MessageBody;
 use actix_web::dev::ServiceFactory;
 use actix_web::web::Data;
 use actix_web::App;
+use dcl_rpc::stream_protocol::GeneratorYielder;
 use quests_db::core::ops::{Connect, GetConnection, Migrate};
 use quests_db::{create_quests_db_component, DatabaseOptions, Executor};
-use quests_message_broker::init_message_broker_components;
+use quests_definitions::quests::UserUpdate;
+use quests_message_broker::init_message_broker_components_with_subscriber;
 use quests_server::api::get_app_router;
 use quests_server::configuration::Config;
 
@@ -33,7 +35,11 @@ pub async fn build_app(
         .await
         .unwrap();
 
-    let (redis, _) = init_message_broker_components(&config.redis_url).await;
+    let (redis, _) =
+        init_message_broker_components_with_subscriber::<GeneratorYielder<UserUpdate>>(
+            &config.redis_url,
+        )
+        .await;
 
     get_app_router(
         &Data::new(config.clone()),

--- a/crates/system/src/event_processing.rs
+++ b/crates/system/src/event_processing.rs
@@ -11,7 +11,7 @@ use quests_definitions::{
     },
     ProstDecodeError, ProstMessage,
 };
-use quests_message_broker::{events_queue::EventsQueue, quests_channel::QuestsChannel};
+use quests_message_broker::{events_queue::EventsQueue, quests_channel::QuestsChannelPublisher};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -43,9 +43,9 @@ impl From<DBError> for ProcessEventError {
 
 pub async fn process_event(
     event: Event,
-    quests_channel: Arc<Mutex<impl QuestsChannel + ?Sized>>,
+    quests_channel: Arc<Mutex<impl QuestsChannelPublisher<UserUpdate> + ?Sized>>,
     database: Arc<impl QuestsDatabase + ?Sized>,
-    events_queue: Arc<impl EventsQueue + ?Sized>,
+    events_queue: Arc<impl EventsQueue<Event> + ?Sized>,
 ) -> ProcessEventResult {
     // get user quest instances
     let quest_instances = database.get_user_quest_instances(&event.address).await;

--- a/crates/system/src/lib.rs
+++ b/crates/system/src/lib.rs
@@ -7,9 +7,10 @@ use event_processing::{process_event, ProcessEventResult};
 use log::{error, info};
 use quests_db::core::definitions::QuestsDatabase;
 use quests_db::create_quests_db_component;
-use quests_message_broker::events_queue::{EventsQueue, RedisEventsQueue};
-use quests_message_broker::quests_channel::{QuestsChannel, RedisQuestsChannel};
-use quests_message_broker::redis::Redis;
+use quests_definitions::quests::{Event, UserUpdate};
+use quests_message_broker::events_queue::EventsQueue;
+use quests_message_broker::init_message_broker_components_with_publisher;
+use quests_message_broker::quests_channel::QuestsChannelPublisher;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -18,34 +19,25 @@ pub type Error = String;
 pub type EventProcessingResult<T> = Result<T, Error>;
 
 pub struct EventProcessor {
-    pub events_queue: Arc<dyn EventsQueue>,
-    quests_channel: Arc<Mutex<dyn QuestsChannel>>,
+    pub events_queue: Arc<dyn EventsQueue<Event>>,
+    quests_channel: Arc<Mutex<dyn QuestsChannelPublisher<UserUpdate>>>,
     database: Arc<dyn QuestsDatabase>,
 }
 
 impl EventProcessor {
-    pub async fn from_config(config: &Config) -> EventProcessingResult<EventProcessor> {
-        // Create Redis pool
-        let redis = Redis::new(&config.redis_url)
-            .await
-            .expect("Can connect to Redis");
-        let redis = Arc::new(redis);
+    pub async fn from_config(config: &Config) -> EventProcessingResult<Self> {
+        let (events_queue, quests_channel) =
+            init_message_broker_components_with_publisher(&config.redis_url).await;
 
-        // Create events queue
-        let events_queue = RedisEventsQueue::new(redis.clone());
         let events_queue = Arc::new(events_queue);
-
-        // Create quests channel
-        let quests_channel = RedisQuestsChannel::new(redis.clone()).await;
         let quests_channel = Arc::new(Mutex::new(quests_channel));
 
-        // Create DB
         let database = create_quests_db_component(&config.database_url)
             .await
             .map_err(|_| "Couldn't connect to the database".to_string())?;
         let database = Arc::new(database);
 
-        Ok(EventProcessor {
+        Ok(Self {
             events_queue,
             quests_channel,
             database,


### PR DESCRIPTION
This PR: 
- makes the message broker crate's components use generics instead of concrete types for optimizations and more flexibility 