### PR TITLE
fix: use case insensitive checks for action type and paremeters

### DIFF
--- a/crates/protocol/src/quest_graph.rs
+++ b/crates/protocol/src/quest_graph.rs
@@ -177,7 +177,7 @@ pub fn matches_action(action: &Action, other_action: &Action) -> bool {
         }
     }
 
-    return true;
+    true
 }
 
 #[cfg(test)]

--- a/crates/protocol/src/quest_state.rs
+++ b/crates/protocol/src/quest_state.rs
@@ -28,7 +28,7 @@ impl QuestState {
                 match task
                     .action_items
                     .iter()
-                    .position(|action| matches_action((action.clone(), event_action.clone())))
+                    .position(|action| matches_action(&action, &event_action))
                 {
                     Some(matched_action_index) => {
                         state

--- a/crates/protocol/src/quests.rs
+++ b/crates/protocol/src/quests.rs
@@ -227,7 +227,7 @@ const LOCATION: &str = "LOCATION";
 const JUMP: &str = "JUMP";
 const NPC_INTERACTION: &str = "NPC_INTERACTION";
 const CUSTOM: &str = "CUSTOM";
-const EMOTE: &str = "EMOTE";
+pub(crate) const EMOTE: &str = "EMOTE";
 
 impl Action {
     pub fn location(coords: Coordinates) -> Self {


### PR DESCRIPTION
# Description

Changes the `matches_action` function to make it case insensitive.

Closes #68 