### PR TITLE
refactor: deactivate old quests on update

### DIFF
--- a/crates/db/README.md
+++ b/crates/db/README.md
@@ -1,16 +1,9 @@
 # Database
 
-The database would be used from more than one service, so here we have some abstractions to reuse queries and setups. 
+The database would be used from more than one service, so here we have some abstractions to reuse queries and setups.
 
 ### Install sqlx-cli:
 
 ```bash
   $ cargo install sqlx-cli --no-default-features --features native-tls,postgres
 ```
-
-### Crates
-
-- db-core: Definitions and traits
-- db-migrations: Migrations and run scripts
-- db-sqlx: Implementation of db-core traits
-

--- a/crates/db/migrations/20230113195325_quests.sql
+++ b/crates/db/migrations/20230113195325_quests.sql
@@ -1,4 +1,3 @@
--- Create quests table
 CREATE TABLE IF NOT EXISTS quests (
   ID UUID PRIMARY KEY NOT NULL,
   name TEXT NOT NULL,
@@ -6,23 +5,34 @@ CREATE TABLE IF NOT EXISTS quests (
   definition bytea NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT now(),
   updated_at TIMESTAMP NOT NULL DEFAULT now()
-  -- TODO: should we add the creator id (address)?
 );
 
--- Create quest_instances table
 CREATE TABLE IF NOT EXISTS quest_instances (
   ID UUID PRIMARY KEY NOT NULL,
-  quest_id UUID references quests(ID) ON DELETE CASCADE,  -- TODO: should not be a FK?
+  quest_id UUID references quests(ID), 
   user_address TEXT NOT NULL,
   start_timestamp TIMESTAMP NOT NULL DEFAULT now()
 );
 
--- Create events table
 CREATE TABLE IF NOT EXISTS events ( 
   ID UUID PRIMARY KEY NOT NULL,
-  quest_instance_id UUID references quest_instances(ID) ON DELETE CASCADE, -- TODO: should not be a FK?
+  quest_instance_id UUID references quest_instances(ID),
   user_address TEXT NOT NULL,
   event bytea NOT NULL,
   timestamp TIMESTAMP NOT NULL DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS deactivated_quests (
+  ID UUID PRIMARY KEY NOT NULL,
+  quest_id UUID references quests(ID), 
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  UNIQUE (quest_id)
+);
+
+CREATE TABLE IF NOT EXISTS quest_updates (
+  ID UUID PRIMARY KEY NOT NULL,
+  quest_id UUID references quests(ID), 
+  previous_quest_id UUID references quests(ID),
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  UNIQUE (quest_id)
+);

--- a/crates/db/src/core/definitions.rs
+++ b/crates/db/src/core/definitions.rs
@@ -6,13 +6,14 @@ use serde::{Deserialize, Serialize};
 pub trait QuestsDatabase: Send + Sync + CloneDatabase {
     async fn ping(&self) -> bool;
 
-    async fn get_quests(&self, offset: i64, limit: i64) -> DBResult<Vec<StoredQuest>>;
     async fn create_quest(&self, quest: &CreateQuest) -> DBResult<String>;
-    async fn update_quest(&self, quest_id: &str, quest: &UpdateQuest) -> DBResult<()>;
+    async fn update_quest(&self, previous_quest_id: &str, quest: &CreateQuest) -> DBResult<String>;
+    async fn deactivate_quest(&self, id: &str) -> DBResult<String>;
     async fn get_quest(&self, id: &str) -> DBResult<StoredQuest>;
-    async fn delete_quest(&self, id: &str) -> DBResult<()>;
-    async fn start_quest(&self, quest_id: &str, user_address: &str) -> DBResult<String>;
+    async fn get_active_quests(&self, offset: i64, limit: i64) -> DBResult<Vec<StoredQuest>>;
+    async fn is_active_quest(&self, quest_id: &str) -> DBResult<bool>;
 
+    async fn start_quest(&self, quest_id: &str, user_address: &str) -> DBResult<String>;
     async fn get_quest_instance(&self, id: &str) -> DBResult<QuestInstance>;
     async fn get_user_quest_instances(&self, user_address: &str) -> DBResult<Vec<QuestInstance>>;
 
@@ -41,13 +42,6 @@ pub struct QuestInstance {
     pub quest_id: String,
     pub user_address: String,
     pub start_timestamp: i64,
-}
-
-#[derive(Default, PartialEq, Serialize, Deserialize, Clone, Debug)]
-pub struct UpdateQuest<'a> {
-    pub name: &'a str,
-    pub description: &'a str,
-    pub definition: Vec<u8>,
 }
 
 #[derive(Default, PartialEq, Serialize, Deserialize, Clone, Debug)]

--- a/crates/db/src/core/errors.rs
+++ b/crates/db/src/core/errors.rs
@@ -10,23 +10,35 @@ pub enum DBError {
     #[error("Unable to migrate: {0}")]
     MigrationError(BoxDynError),
 
+    #[error("Unable to begin transaction: {0}")]
+    TransactionBeginFailed(BoxDynError),
+
+    #[error("Unable to commit or rollback transaction: {0}")]
+    TransactionFailed(BoxDynError),
+
     #[error("Unable to create a quest: {0}")]
     CreateQuestFailed(BoxDynError),
 
     #[error("Unable to get a quest: {0}")]
     GetQuestFailed(BoxDynError),
 
+    #[error("Unable to get a quests")]
+    GetQuestsFailed(BoxDynError),
+
     #[error("Unable to update a quest: {0}")]
     UpdateQuestFailed(BoxDynError),
 
-    #[error("Unable to delete a quest: {0}")]
-    DeleteQuestFailed(BoxDynError),
+    #[error("Unable to deactivate a quest: {0}")]
+    DeactivateQuestFailed(BoxDynError),
 
     #[error("Unable to create a quest instance: {0}")]
     StartQuestFailed(BoxDynError),
 
     #[error("Unable to get a quest instance: {0}")]
     GetQuestInstanceFailed(BoxDynError),
+
+    #[error("Unable to get an event for a quest: {0}")]
+    GetQuestEventsFailed(BoxDynError),
 
     #[error("Unable to store an event for a quest: {0}")]
     CreateQuestEventFailed(BoxDynError),

--- a/crates/server/src/api/routes/quests/delete_quest.rs
+++ b/crates/server/src/api/routes/quests/delete_quest.rs
@@ -28,7 +28,7 @@ async fn delete_quest_controller<DB: QuestsDatabase>(
     db: Arc<DB>,
     id: String,
 ) -> Result<(), CommonError> {
-    db.delete_quest(&id)
+    db.deactivate_quest(&id)
         .await
         .map(|_| ())
         .map_err(|error| error.into())

--- a/crates/server/src/api/routes/quests/get_quests.rs
+++ b/crates/server/src/api/routes/quests/get_quests.rs
@@ -47,7 +47,7 @@ async fn get_quests_controller<DB: QuestsDatabase>(
     offset: i64,
     limit: i64,
 ) -> Result<Vec<StoredQuest>, CommonError> {
-    db.get_quests(offset, limit)
+    db.get_active_quests(offset, limit)
         .await
         .map_err(|_| CommonError::Unknown)
 }

--- a/crates/server/src/api/routes/quests/types.rs
+++ b/crates/server/src/api/routes/quests/types.rs
@@ -1,4 +1,4 @@
-use quests_db::core::definitions::{StoredQuest, UpdateQuest};
+use quests_db::core::definitions::{CreateQuest, StoredQuest};
 use quests_protocol::{
     quests::{Quest, QuestDefinition},
     ProtocolMessage,
@@ -10,8 +10,8 @@ pub trait ToQuest {
     fn to_quest(&self) -> Result<Quest, QuestError>;
 }
 
-pub trait ToUpdateQuest {
-    fn to_update_quest(&self) -> Result<UpdateQuest, QuestError>;
+pub trait ToCreateQuest {
+    fn to_create_quest(&self) -> Result<CreateQuest, QuestError>;
 }
 
 impl ToQuest for StoredQuest {
@@ -25,9 +25,9 @@ impl ToQuest for StoredQuest {
     }
 }
 
-impl ToUpdateQuest for Quest {
-    fn to_update_quest(&self) -> Result<UpdateQuest, QuestError> {
-        Ok(UpdateQuest {
+impl ToCreateQuest for Quest {
+    fn to_create_quest(&self) -> Result<CreateQuest, QuestError> {
+        Ok(CreateQuest {
             name: &self.name,
             description: &self.description,
             definition: self.definition.encode_to_vec(),

--- a/crates/server/src/api/routes/quests/update_quest.rs
+++ b/crates/server/src/api/routes/quests/update_quest.rs
@@ -9,7 +9,7 @@ use utoipa::ToSchema;
 
 use crate::domain::quests::QuestError;
 
-use super::types::ToUpdateQuest;
+use super::types::ToCreateQuest;
 
 #[derive(Serialize, Deserialize, Debug, ToSchema, Deref)]
 pub struct UpdateQuestRequest(Quest);
@@ -50,7 +50,7 @@ async fn update_quest_controller<DB: QuestsDatabase>(
 ) -> Result<Quest, QuestError> {
     match quest.is_valid() {
         Ok(_) => db
-            .update_quest(&id, &quest.to_update_quest()?)
+            .update_quest(&id, &quest.to_create_quest()?)
             .await
             .map(|_| quest)
             .map_err(|error| error.into()),

--- a/crates/server/src/api/routes/quests/update_quest.rs
+++ b/crates/server/src/api/routes/quests/update_quest.rs
@@ -14,8 +14,11 @@ use super::types::ToCreateQuest;
 #[derive(Serialize, Deserialize, Debug, ToSchema, Deref)]
 pub struct UpdateQuestRequest(Quest);
 
-#[derive(Serialize, Deserialize, Debug, ToSchema, Deref)]
-pub struct UpdateQuestResponse(Quest);
+#[derive(Serialize, Deserialize, Debug, ToSchema)]
+pub struct UpdateQuestResponse {
+    pub quest: Quest,
+    pub quest_id: String,
+}
 
 #[utoipa::path(
     request_body = UpdateQuestRequest,
@@ -23,7 +26,7 @@ pub struct UpdateQuestResponse(Quest);
         ("quest_id" = String, Path, description = "Quest ID")    
     ),
     responses(
-        (status = 200, description = "Quest updated"),
+        (status = 200, description = "Quest updated", body = UpdateQuestResponse),
         (status = 400, description = "Bad Request"),
         (status = 404, description = "Quest not found"),
         (status = 500, description = "Internal Server Error")
@@ -37,8 +40,12 @@ pub async fn update_quest(
 ) -> HttpResponse {
     let db = data.into_inner();
     let quest_id = quest_id.into_inner();
-    match update_quest_controller(db, quest_id, quest_update.0 .0).await {
-        Ok(quest) => HttpResponse::Ok().json(UpdateQuestResponse(quest)),
+    let quest = quest_update.into_inner();
+    match update_quest_controller(db, quest_id, &quest).await {
+        Ok(quest_id) => HttpResponse::Ok().json(UpdateQuestResponse {
+            quest_id,
+            quest: quest.0,
+        }),
         Err(error) => HttpResponse::from_error(error),
     }
 }
@@ -46,13 +53,12 @@ pub async fn update_quest(
 async fn update_quest_controller<DB: QuestsDatabase>(
     db: Arc<DB>,
     id: String,
-    quest: Quest,
-) -> Result<Quest, QuestError> {
+    quest: &Quest,
+) -> Result<String, QuestError> {
     match quest.is_valid() {
         Ok(_) => db
             .update_quest(&id, &quest.to_create_quest()?)
             .await
-            .map(|_| quest)
             .map_err(|error| error.into()),
         Err(error) => Err(QuestError::QuestValidation(error.to_string())),
     }

--- a/crates/server/src/domain/quests.rs
+++ b/crates/server/src/domain/quests.rs
@@ -26,9 +26,15 @@ pub async fn start_quest_controller(
     db: Arc<impl QuestsDatabase>,
     start_quest_request: StartQuestRequest,
 ) -> Result<String, QuestError> {
-    db.get_quest(&start_quest_request.quest_id)
+    let is_active = db
+        .is_active_quest(&start_quest_request.quest_id)
         .await
         .map_err(|err| -> QuestError { err.into() })?;
+    if !is_active {
+        return Err(QuestError::CommonError(CommonError::BadRequest(
+            "Quest not found or inactive".to_string(),
+        )));
+    }
 
     db.start_quest(
         &start_quest_request.quest_id,

--- a/crates/server/tests/deactivate_quest.rs
+++ b/crates/server/tests/deactivate_quest.rs
@@ -7,7 +7,7 @@ use quests_protocol::quests::{Quest, QuestDefinition};
 use quests_server::api::routes::ErrorResponse;
 
 #[actix_web::test]
-async fn delete_quest_should_be_200() {
+async fn deactivate_quest_should_be_200() {
     let config = get_configuration().await;
     let db = create_quests_db_component(&config.database_url)
         .await
@@ -39,7 +39,7 @@ async fn delete_quest_should_be_200() {
 
     assert!(response.status().is_success());
 
-    assert!(db.get_quest(&id).await.is_err());
+    assert!(!db.is_active_quest(&id).await.unwrap());
 }
 
 #[actix_web::test]


### PR DESCRIPTION
# Description

These changes propose deactivating quests instead of deleting them. In order to support that:
- on delete =>
   - deactivate: insert row in new table (deactivated_quests)
- on update =>
   - create a new quest
   - deactivate old quest
   - add an update (from -> to) in a new table (quest_updates)
   - quest instances already started will continue living with previous quest definitions
- on start  =>
   - only active quests can be started

Closes #66 