### PR TITLE
feat(benchmark): use signed headers authentication method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,6 +2465,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dcl-crypto",
+ "dcl-crypto-middleware-rs",
  "dcl-rpc",
  "env_logger",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "dcl-crypto-middleware-rs"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b80ad648f94a6fd4790e2e5e280cd56e98f5e01700ed40d0d5fd987db9b37e6"
+checksum = "f9eb528d4060060efc36544d3d8b225a8d0691559977dda589ef98067b363243"
 dependencies = [
  "async-trait",
  "dcl-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,16 @@
 [workspace]
-members=["crates/*"]
+members = ["crates/*"]
 
 [workspace.dependencies]
 actix-web = "4.2.1"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.6", features = [ "runtime-actix-native-tls" , "postgres", "uuid", "json", "chrono" ] }
+sqlx = { version = "0.6", features = [
+  "runtime-actix-native-tls",
+  "postgres",
+  "uuid",
+  "json",
+  "chrono",
+] }
 log = "0.4.16"
 env_logger = "0.10.0"
 config = "0.13"
@@ -12,7 +18,7 @@ serde = "1"
 serde_json = "1"
 dcl-rpc = "2.3.5"
 dcl-crypto = "0.2.1"
-uuid = {version = "1.2.2", features = ["v4"]}
+uuid = { version = "1.2.2", features = ["v4"] }
 
 [profile.release]
 strip = true

--- a/crates/benchmark/Cargo.toml
+++ b/crates/benchmark/Cargo.toml
@@ -19,4 +19,4 @@ clap = { version = "4.2.7", features = ["derive"] }
 tungstenite = "0.18"
 serde_json = "1.0"
 dcl-crypto = { workspace = true }
-
+dcl-crypto-middleware-rs = { version = "0.2.0", features = ["ws_signed_headers", "signed_fetch"]}

--- a/crates/benchmark/src/args.rs
+++ b/crates/benchmark/src/args.rs
@@ -38,4 +38,7 @@ pub struct Args {
 
     #[arg(short, long, default_value_t = true, help = "Authenticate WebSocket")]
     pub authenticate: bool,
+
+    #[arg(short, long, default_value_t = 10, help = "Amount of quests to create")]
+    pub quests: u8,
 }

--- a/crates/benchmark/src/client.rs
+++ b/crates/benchmark/src/client.rs
@@ -1,9 +1,6 @@
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use dcl_crypto::{
-    account::{Account, Signer},
-    AuthChain,
-};
+use dcl_crypto::{account::Account, Expiration, Identity};
 use dcl_rpc::{
     client::RpcClient,
     transports::web_sockets::{
@@ -38,28 +35,39 @@ pub async fn handle_client(
     })?;
 
     let ws = if authenticate {
-        match ws.receive().await {
-            Some(Ok(Message::Text(challenge))) => {
-                let account = Account::random();
-                let signature = account.sign(&challenge);
-                let auth_chain =
-                    AuthChain::simple(account.address(), &challenge, signature.to_string())
-                        .map_err(|_| ClientCreationError::Authentication)?;
-                let auth_chain = serde_json::to_string(&auth_chain)
-                    .map_err(|_| ClientCreationError::Authentication)?;
-                ws.send(Message::Text(auth_chain))
-                    .await
-                    .map_err(|_| ClientCreationError::Authentication)?;
-                ws.clone().ping_every(Duration::from_secs(30)).await;
-                ws
-            }
-            _ => return Err(ClientCreationError::Authentication),
-        }
+        let signer = Account::random();
+        let identity = Identity::from_signer(
+            &signer,
+            Expiration::try_from("3021-10-16T22:32:29.626Z").unwrap(),
+        );
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+
+        let path = "/";
+        let method = "get";
+        let metadata = "{}";
+        let auth_chain = identity.sign_payload(format!("{method}:{path}:{now}:{metadata}"));
+        let signed_headers = format!(
+            r#"{{"X-Identity-Auth-Chain-0": {},  "X-Identity-Auth-Chain-1": {},  "X-Identity-Auth-Chain-2": {}, "X-Identity-Timestamp": {}, "X-Identity-Metadata": {} }}"#,
+            serde_json::to_string(auth_chain.get(0).unwrap()).unwrap(),
+            serde_json::to_string(auth_chain.get(1).unwrap()).unwrap(),
+            serde_json::to_string(auth_chain.get(2).unwrap()).unwrap(),
+            now,
+            "{}"
+        );
+
+        ws.send(Message::Text(signed_headers))
+            .await
+            .map_err(|_| ClientCreationError::Authentication)?;
+
+        ws
     } else {
-        ws.clone().ping_every(Duration::from_secs(30)).await;
         ws
     };
 
+    ws.clone().ping_every(Duration::from_secs(30)).await;
     let transport = WebSocketTransport::new(ws);
 
     let client_connection = Instant::now();

--- a/crates/benchmark/src/quests_simulation.rs
+++ b/crates/benchmark/src/quests_simulation.rs
@@ -287,13 +287,12 @@ impl Context for TestContext {
     async fn init(args: &Args) -> Self {
         let mut quest_ids = vec![];
 
-        for _ in 0..50 {
+        for _ in 0..args.quests {
             match Self::create_random_quest(&args.api_host).await {
                 Ok(quest_id) => quest_ids.push(quest_id),
                 Err(reason) => debug!("Quest Creation > Couldn't POST quest: {reason}"),
             }
         }
-
         Self {
             quest_ids,
             timeout: Duration::from_secs(args.timeout as u64),

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -9,12 +9,14 @@ quests_protocol = { path = "../protocol/" }
 quests_db = { path = "../db" }
 quests_message_broker = { path = "../message_broker/" }
 dcl-rpc = { workspace = true, features = ["warp"] }
-actix-web = { workspace = true } 
+actix-web = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 config = { workspace = true }
 log = { workspace = true }
 dcl-crypto = { workspace = true }
+uuid = { workspace = true }
+
 actix-web-prom = "0.6.0"
 async-trait = "0.1.57"
 tracing = "0.1"
@@ -32,8 +34,10 @@ derive_more = "0.99.17"
 warp = "0.3.3"
 tungstenite = "0.19.0"
 fastrand = "1.9.0"
-uuid = { workspace = true }
-dcl-crypto-middleware-rs = { version = "0.2.0", features = ["ws_signed_headers", "signed_fetch"]}
+dcl-crypto-middleware-rs = { version = "0.2.1", features = [
+  "ws_signed_headers",
+  "signed_fetch",
+] }
 
 [dev-dependencies]
 uuid = { workspace = true }


### PR DESCRIPTION
## Description

- **[Quests Benchmark]** Send signed headers to authenticate `ws` connection
- Bumps `dcl-crypto-middleware-rs` 