### PR TITLE
refactor: quests proto definitions to include relevant information

### DIFF
--- a/crates/benchmark/src/client.rs
+++ b/crates/benchmark/src/client.rs
@@ -79,3 +79,63 @@ pub async fn handle_client(
 
     Ok((client, whole_connection, client_creation_elapsed))
 }
+
+pub fn create_test_identity() -> dcl_crypto::Identity {
+    dcl_crypto::Identity::from_json(
+      r#"{
+     "ephemeralIdentity": {
+       "address": "0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34",
+       "publicKey": "0x0420c548d960b06dac035d1daf826472eded46b8b9d123294f1199c56fa235c89f2515158b1e3be0874bfb15b42d1551db8c276787a654d0b8d7b4d4356e70fe42",
+       "privateKey": "0xbc453a92d9baeb3d10294cbc1d48ef6738f718fd31b4eb8085efe7b311299399"
+     },
+     "expiration": "3021-10-16T22:32:29.626Z",
+     "authChain": [
+       {
+         "type": "SIGNER",
+         "payload": "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5",
+         "signature": ""
+       },
+       {
+         "type": "ECDSA_EPHEMERAL",
+         "payload": "Decentraland Login\nEphemeral address: 0x84452bbFA4ca14B7828e2F3BBd106A2bD495CD34\nExpiration: 3021-10-16T22:32:29.626Z",
+         "signature": "0x39dd4ddf131ad2435d56c81c994c4417daef5cf5998258027ef8a1401470876a1365a6b79810dc0c4a2e9352befb63a9e4701d67b38007d83ffc4cd2b7a38ad51b"
+       }
+     ]
+    }"#,
+  ).unwrap()
+}
+
+pub fn get_signed_headers(
+    identity: Identity,
+    method: &str,
+    path: &str,
+    metadata: &str,
+) -> Vec<(String, String)> {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+
+    let payload = [method, path, &ts.to_string(), metadata]
+        .join(":")
+        .to_lowercase();
+
+    let authchain = identity.sign_payload(payload);
+
+    vec![
+        (
+            "X-Identity-Auth-Chain-0".to_string(),
+            serde_json::to_string(authchain.get(0).unwrap()).unwrap(),
+        ),
+        (
+            "X-Identity-Auth-Chain-1".to_string(),
+            serde_json::to_string(authchain.get(1).unwrap()).unwrap(),
+        ),
+        (
+            "X-Identity-Auth-Chain-2".to_string(),
+            serde_json::to_string(authchain.get(2).unwrap()).unwrap(),
+        ),
+        ("X-Identity-Timestamp".to_string(), ts.to_string()),
+        ("X-Identity-Metadata".to_string(), metadata.to_string()),
+    ]
+}

--- a/crates/benchmark/src/quests.rs
+++ b/crates/benchmark/src/quests.rs
@@ -53,6 +53,7 @@ pub fn random_quest() -> Quest {
     }
 
     Quest {
+        id: "8e9b8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: create_random_string(10),
         description: create_random_string(100),
         definition: Some(QuestDefinition { connections, steps }),
@@ -61,6 +62,7 @@ pub fn random_quest() -> Quest {
 
 pub fn grab_some_apples() -> Quest {
     Quest {
+        id: "8e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {
@@ -113,6 +115,7 @@ pub fn grab_some_apples() -> Quest {
 
 pub fn grab_some_pies() -> Quest {
     Quest {
+        id: "8e9a8bbf-2223-4f51-b7e5-000d35cedef4".to_string(),
         name: "QUEST-2".to_string(),
         description: "Grab some pies".to_string(),
         definition: Some(QuestDefinition {

--- a/crates/benchmark/src/quests.rs
+++ b/crates/benchmark/src/quests.rs
@@ -1,6 +1,7 @@
 use quests_protocol::definitions::*;
 use quests_protocol::quests::*;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use serde::Serialize;
 
 pub fn create_random_string(length: usize) -> String {
     thread_rng()
@@ -14,7 +15,14 @@ fn random_action() -> Action {
     Action::custom(&create_random_string(10))
 }
 
-pub fn random_quest() -> Quest {
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateQuestRequest {
+    name: String,
+    description: String,
+    definition: QuestDefinition,
+}
+
+pub fn random_quest() -> CreateQuestRequest {
     let mut connections = vec![];
     let mut steps = vec![];
     let mut rng = rand::thread_rng();
@@ -52,11 +60,10 @@ pub fn random_quest() -> Quest {
         }
     }
 
-    Quest {
-        id: "8e9b8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    CreateQuestRequest {
         name: create_random_string(10),
         description: create_random_string(100),
-        definition: Some(QuestDefinition { connections, steps }),
+        definition: QuestDefinition { connections, steps },
     }
 }
 
@@ -113,12 +120,11 @@ pub fn grab_some_apples() -> Quest {
     }
 }
 
-pub fn grab_some_pies() -> Quest {
-    Quest {
-        id: "8e9a8bbf-2223-4f51-b7e5-000d35cedef4".to_string(),
+pub fn grab_some_pies() -> CreateQuestRequest {
+    CreateQuestRequest {
         name: "QUEST-2".to_string(),
         description: "Grab some pies".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![
                 Connection::new("A", "B"),
                 Connection::new("B", "C"),
@@ -162,16 +168,24 @@ pub fn grab_some_pies() -> Quest {
                     description: "".to_string(),
                 },
             ],
-        }),
+        },
     }
 }
 
 mod tests {
+
     #[test]
     fn random_quest_is_valid() {
         use super::random_quest;
+        use quests_protocol::definitions::Quest;
         let quest = random_quest();
 
+        let quest = Quest {
+            id: "8e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+            name: quest.name,
+            description: quest.description,
+            definition: Some(quest.definition),
+        };
         println!("Quest {quest:#?}");
         let valid = quest.is_valid();
 

--- a/crates/benchmark/src/quests_simulation.rs
+++ b/crates/benchmark/src/quests_simulation.rs
@@ -166,15 +166,15 @@ impl ClientState {
                 match quest_updates {
                     Some(UserUpdate {
                         message:
-                            Some(user_update::Message::NewQuestStarted(QuestStateWithData {
-                                quest_instance_id,
-                                quest_state: Some(state),
+                            Some(user_update::Message::NewQuestStarted(QuestInstance {
+                                id,
+                                state: Some(state),
                                 ..
                             })),
                         ..
                     }) => ClientState::MakeQuestProgress {
                         updates,
-                        quest_instance_id,
+                        quest_instance_id: id,
                         quest_state: state,
                     },
                     _ => {
@@ -238,12 +238,11 @@ impl ClientState {
                 match quest_update {
                     Some(update) => match update.message {
                         Some(user_update::Message::QuestStateUpdate(QuestStateUpdate {
-                            quest_data: Some(state),
+                            quest_state: Some(state),
+                            instance_id,
                             ..
-                        })) if state.quest_instance_id == quest_instance_id
-                            && state.quest_state.is_some() =>
-                        {
-                            let new_quest_state = state.quest_state.unwrap();
+                        })) if instance_id == quest_instance_id => {
+                            let new_quest_state = state;
                             if new_quest_state.steps_left == 0 {
                                 ClientState::QuestFinished { updates }
                             } else {

--- a/crates/benchmark/src/simulation.rs
+++ b/crates/benchmark/src/simulation.rs
@@ -42,8 +42,8 @@ impl Simulation {
         let clients = Arc::new(Mutex::new(clients));
         let context = Arc::new(context);
 
-        debug!("Simulation > Wait for 10s before start...");
-        sleep(Duration::from_secs(10));
+        debug!("Simulation > Wait for 1s before start...");
+        sleep(Duration::from_secs(1));
         let mut futures = FuturesUnordered::new();
         for worker_id in 0..args.parallel {
             futures.push(tokio::spawn(worker(

--- a/crates/protocol/src/main.rs
+++ b/crates/protocol/src/main.rs
@@ -4,6 +4,7 @@ fn main() {
     println!("Quests definitions:");
 
     let branched_quest = Quest {
+        id: "1e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "CUSTOM_QUEST".to_string(),
         description: "".to_string(),
         definition: Some(QuestDefinition {

--- a/crates/protocol/src/quests/builders.rs
+++ b/crates/protocol/src/quests/builders.rs
@@ -173,9 +173,11 @@ impl EventResponse {
 }
 
 impl GetAllQuestsResponse {
-    pub fn ok(quests: Vec<QuestInstance>) -> Self {
+    pub fn ok(instances: Vec<QuestInstance>) -> Self {
         Self {
-            response: Some(get_all_quests_response::Response::Quests(Quests { quests })),
+            response: Some(get_all_quests_response::Response::Quests(Quests {
+                instances,
+            })),
         }
     }
 
@@ -192,6 +194,7 @@ impl GetQuestDefinitionResponse {
     pub fn ok(quest: Quest) -> Self {
         Self {
             response: Some(get_quest_definition_response::Response::Quest(Quest {
+                id: quest.id,
                 name: quest.name,
                 description: quest.description,
                 definition: quest.definition,

--- a/crates/protocol/src/quests/graph.rs
+++ b/crates/protocol/src/quests/graph.rs
@@ -112,7 +112,7 @@ fn build_graph_from_quest_definition(quest: &Quest) -> Dag<String, u32> {
     } in &definition.connections
     {
         // Validate if steps are in defined in the quest
-        if quest.contanins_step(step_from) && quest.contanins_step(step_to) {
+        if quest.contains_step(step_from) && quest.contains_step(step_to) {
             if let Some(node_from) = nodes.get(step_from) {
                 let (_, node_to) =
                     dag.add_child(*node_from, node_from.index() as u32, step_to.clone());

--- a/crates/protocol/src/quests/graph.rs
+++ b/crates/protocol/src/quests/graph.rs
@@ -192,6 +192,7 @@ mod tests {
     #[test]
     fn build_quest_graph_properly() {
         let quest = Quest {
+            id: "1e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -260,6 +261,7 @@ mod tests {
     #[test]
     fn build_quest_graph_with_multiple_starting_points_properly() {
         let quest = Quest {
+            id: "1e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -347,6 +349,7 @@ mod tests {
     #[test]
     fn build_quest_graph_with_multiple_pivot_points() {
         let quest = Quest {
+            id: "1e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -443,6 +446,7 @@ mod tests {
     #[test]
     fn quest_graph_prev_works_properly() {
         let quest = Quest {
+            id: "1e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -514,6 +518,7 @@ mod tests {
     #[test]
     fn quest_graph_steps_required_for_end() {
         let quest = Quest {
+            id: "1e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {

--- a/crates/protocol/src/quests/mod.rs
+++ b/crates/protocol/src/quests/mod.rs
@@ -226,6 +226,7 @@ mod tests {
     #[test]
     fn get_starting_steps_properly() {
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -249,6 +250,7 @@ mod tests {
     #[test]
     fn get_steps_pointing_to_end_properly() {
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -272,6 +274,7 @@ mod tests {
     #[test]
     fn quest_should_be_valid() {
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -315,6 +318,7 @@ mod tests {
     fn quest_should_not_be_valid() {
         // Should not be valid because of missing connections and steps
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -330,6 +334,7 @@ mod tests {
 
         // Should not be valid because of missing step for starting ndoe
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -350,6 +355,7 @@ mod tests {
 
         // Should not be valid because of missing step for end ndoe
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -370,6 +376,8 @@ mod tests {
 
         // Should not be valid because of missing connection for a defined step
         let quest = Quest {
+            id: "".to_string(),
+
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -410,6 +418,7 @@ mod tests {
 
         // Should not be valid because of missing step for a defined connection
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -441,6 +450,7 @@ mod tests {
 
         // Should not be valid because of repeated ID for step
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -490,6 +500,7 @@ mod tests {
 
         // Should not be valid because of repeated ID on subtasks
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -537,6 +548,7 @@ mod tests {
 
         // Should not be valid because of Tasks::None
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {

--- a/crates/protocol/src/quests/mod.rs
+++ b/crates/protocol/src/quests/mod.rs
@@ -17,11 +17,11 @@ pub type StepID = String;
 
 impl Quest {
     /// Check if the quest has a step defined by its id
-    pub fn contanins_step(&self, step_id: &StepID) -> bool {
+    pub fn contains_step(&self, step_id: &StepID) -> bool {
         let Some(definition) = &self.definition else {
             return false;
         };
-        definition.steps.iter().any(|step| step.id == *step_id)
+        definition.contains_step(step_id)
     }
 
     /// Get step defined in the quest by its id
@@ -29,7 +29,7 @@ impl Quest {
         let Some(definition) = &self.definition else {
             return None;
         };
-        definition.steps.iter().find(|step| step.id == *step_id)
+        definition.get_step(step_id)
     }
 
     /// Get all steps in `connections` that don't have a connection defined in which they are the `from` pointing to other node.
@@ -37,21 +37,10 @@ impl Quest {
     /// We use this in order to know which steps point to the end node
     ///
     pub(crate) fn get_steps_without_to(&self) -> HashSet<StepID> {
-        let mut steps = HashSet::new();
         let Some(definition) = &self.definition else {
-            return steps;
+            return HashSet::new();
         };
-        for connection in &definition.connections {
-            if definition
-                .connections
-                .iter()
-                .all(|conn| conn.step_from != connection.step_to)
-            {
-                steps.insert(connection.step_to.clone());
-            }
-        }
-
-        steps
+        definition.get_steps_without_to()
     }
 
     /// Get all steps in `connections` that don't have a connection defined in which they are the `to`.
@@ -59,21 +48,10 @@ impl Quest {
     /// We use this in order to know which steps are possible starting points
     ///
     pub(crate) fn get_steps_without_from(&self) -> HashSet<StepID> {
-        let mut steps = HashSet::new();
         let Some(definition) = &self.definition else {
-            return steps;
+            return HashSet::new();
         };
-        for connection in &definition.connections {
-            if definition
-                .connections
-                .iter()
-                .all(|conn| conn.step_to != connection.step_from)
-            {
-                steps.insert(connection.step_from.clone());
-            }
-        }
-
-        steps
+        definition.get_steps_without_from()
     }
 
     /// Validates a Quest struct to check if it meets all the requirements to be a valid quests
@@ -82,6 +60,13 @@ impl Quest {
         let Some(definition) = &self.definition else {
             return Err(QuestValidationError::InvalidDefinition);
         };
+        definition.is_valid()
+    }
+}
+
+impl QuestDefinition {
+    pub fn is_valid(&self) -> Result<(), QuestValidationError> {
+        let definition = self;
         if definition.connections.is_empty() || definition.steps.is_empty() {
             return Err(QuestValidationError::InvalidDefinition);
         }
@@ -93,7 +78,7 @@ impl Quest {
         }
         // All starting nodes should be defined as Step
         for step_id in starting_nodes {
-            if !self.contanins_step(&step_id) {
+            if !self.contains_step(&step_id) {
                 return Err(QuestValidationError::MissingStepForStartingNode(step_id));
             }
         }
@@ -105,7 +90,7 @@ impl Quest {
         }
         // All end nodes should be defined as Step
         for step_id in end_nodes {
-            if !self.contanins_step(&step_id) {
+            if !self.contains_step(&step_id) {
                 return Err(QuestValidationError::MissingStepForEndNode(step_id));
             }
         }
@@ -153,20 +138,58 @@ impl Quest {
             ref step_to,
         } in &definition.connections
         {
-            if !self.contanins_step(step_from) {
+            if !self.contains_step(step_from) {
                 return Err(QuestValidationError::NoStepDefinedForConnectionHalf(
                     step_from.clone(),
                 ));
             }
 
-            if !self.contanins_step(step_to) {
+            if !self.contains_step(step_to) {
                 return Err(QuestValidationError::NoStepDefinedForConnectionHalf(
                     step_to.clone(),
                 ));
             }
         }
-
         Ok(())
+    }
+
+    fn contains_step(&self, step_id: &StepID) -> bool {
+        self.steps.iter().any(|step| step.id == *step_id)
+    }
+
+    /// Get step defined in the quest by its id
+    fn get_step(&self, step_id: &StepID) -> Option<&Step> {
+        self.steps.iter().find(|step| step.id == *step_id)
+    }
+
+    fn get_steps_without_to(&self) -> HashSet<StepID> {
+        let mut steps = HashSet::new();
+        for connection in &self.connections {
+            if self
+                .connections
+                .iter()
+                .all(|conn| conn.step_from != connection.step_to)
+            {
+                steps.insert(connection.step_to.clone());
+            }
+        }
+
+        steps
+    }
+
+    fn get_steps_without_from(&self) -> HashSet<StepID> {
+        let mut steps = HashSet::new();
+        for connection in &self.connections {
+            if self
+                .connections
+                .iter()
+                .all(|conn| conn.step_to != connection.step_from)
+            {
+                steps.insert(connection.step_from.clone());
+            }
+        }
+
+        steps
     }
 }
 

--- a/crates/protocol/src/quests/state.rs
+++ b/crates/protocol/src/quests/state.rs
@@ -121,6 +121,7 @@ mod tests {
     #[test]
     fn quest_graph_apply_event_task_simple_works() {
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {
@@ -299,6 +300,7 @@ mod tests {
     #[test]
     fn quest_graph_apply_event_task_multiple_works() {
         let quest = Quest {
+            id: "".to_string(),
             name: "CUSTOM_QUEST".to_string(),
             description: "".to_string(),
             definition: Some(QuestDefinition {

--- a/crates/server/src/api/routes/quests/update_quest.rs
+++ b/crates/server/src/api/routes/quests/update_quest.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use actix_web::{put, web, HttpRequest, HttpResponse};
 use derive_more::Deref;
 use quests_db::{core::definitions::QuestsDatabase, Database};
-use quests_protocol::definitions::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -11,12 +10,13 @@ use crate::api::routes::quests::get_user_address_from_request;
 use crate::domain::quests::QuestError;
 use crate::domain::types::ToCreateQuest;
 
+use super::CreateQuestRequest;
+
 #[derive(Serialize, Deserialize, Debug, ToSchema, Deref)]
-pub struct UpdateQuestRequest(Quest);
+pub struct UpdateQuestRequest(CreateQuestRequest);
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]
 pub struct UpdateQuestResponse {
-    pub quest: Quest,
     pub quest_id: String,
 }
 
@@ -51,10 +51,7 @@ pub async fn update_quest(
     };
 
     match update_quest_controller(db, quest_id, &quest, &user).await {
-        Ok(quest_id) => HttpResponse::Ok().json(UpdateQuestResponse {
-            quest_id,
-            quest: quest.0,
-        }),
+        Ok(quest_id) => HttpResponse::Ok().json(UpdateQuestResponse { quest_id }),
         Err(error) => HttpResponse::from_error(error),
     }
 }
@@ -62,7 +59,7 @@ pub async fn update_quest(
 async fn update_quest_controller<DB: QuestsDatabase>(
     db: Arc<DB>,
     id: String,
-    quest: &Quest,
+    quest: &CreateQuestRequest,
     creator_address: &str,
 ) -> Result<String, QuestError> {
     if let Err(err) = quest.is_valid() {

--- a/crates/server/src/domain/types.rs
+++ b/crates/server/src/domain/types.rs
@@ -15,6 +15,7 @@ impl ToQuest for StoredQuest {
     fn to_quest(&self) -> Result<Quest, QuestError> {
         let definition = QuestDefinition::decode(self.definition.as_slice())?;
         Ok(Quest {
+            id: self.id.clone(),
             name: self.name.to_string(),
             description: self.description.to_string(),
             definition: Some(definition),
@@ -28,6 +29,7 @@ impl ToCreateQuest for Quest {
             name,
             description,
             definition,
+            ..
         } = self;
 
         let Some(definition) = definition else {

--- a/crates/server/src/rpc/service.rs
+++ b/crates/server/src/rpc/service.rs
@@ -23,7 +23,6 @@ type QuestRpcResult<T> = Result<T, ServiceErrors>;
 
 #[async_trait::async_trait]
 impl QuestsServiceServer<QuestsRpcServerContext, ServiceErrors> for QuestsServiceImplementation {
-    // TODO: Add tracing instrument
     async fn start_quest(
         &self,
         request: StartQuestRequest,
@@ -62,7 +61,7 @@ impl QuestsServiceServer<QuestsRpcServerContext, ServiceErrors> for QuestsServic
                             let user_update = UserUpdate {
                                 message: Some(user_update::Message::NewQuestStarted(
                                     QuestInstance {
-                                        id: quest_id,
+                                        id: new_quest_instance_id,
                                         quest: Some(quest),
                                         state: Some(quest_state),
                                     },
@@ -93,7 +92,6 @@ impl QuestsServiceServer<QuestsRpcServerContext, ServiceErrors> for QuestsServic
         }
     }
 
-    // TODO: Add tracing instrument
     async fn abort_quest(
         &self,
         request: AbortQuestRequest,
@@ -128,7 +126,6 @@ impl QuestsServiceServer<QuestsRpcServerContext, ServiceErrors> for QuestsServic
         }
     }
 
-    // TODO: Add tracing instrument
     async fn send_event(
         &self,
         request: EventRequest,
@@ -160,7 +157,6 @@ impl QuestsServiceServer<QuestsRpcServerContext, ServiceErrors> for QuestsServic
         }
     }
 
-    // TODO: Add tracing instrument
     async fn subscribe(
         &self,
         context: ProcedureContext<QuestsRpcServerContext>,

--- a/crates/server/tests/common/quest_samples.rs
+++ b/crates/server/tests/common/quest_samples.rs
@@ -3,6 +3,7 @@ use quests_protocol::quests::*;
 
 pub fn grab_some_apples() -> Quest {
     Quest {
+        id: "3e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {
@@ -56,6 +57,7 @@ pub fn grab_some_apples() -> Quest {
 #[allow(dead_code)]
 pub fn grab_some_pies() -> Quest {
     Quest {
+        id: "1e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-2".to_string(),
         description: "Grab some pies".to_string(),
         definition: Some(QuestDefinition {
@@ -114,6 +116,7 @@ pub fn one_step_quest() -> (Quest, Action) {
         parameters: HashMap::new(),
     };
     let quest = Quest {
+        id: "2e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "One step quest".to_string(),
         description: "Jump".to_string(),
         definition: Some(QuestDefinition {

--- a/crates/server/tests/create_quest.rs
+++ b/crates/server/tests/create_quest.rs
@@ -39,6 +39,7 @@ async fn create_quest_should_be_400_quest_validation_error() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
     let quest_definition = Quest {
+        id: "3e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {
@@ -79,6 +80,7 @@ async fn create_quest_should_be_401() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
     let quest_definition = Quest {
+        id: "4e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {

--- a/crates/server/tests/create_quest.rs
+++ b/crates/server/tests/create_quest.rs
@@ -3,7 +3,7 @@ use actix_web::test::{call_service, init_service, read_body_json, try_call_servi
 use actix_web_lab::__reexports::serde_json;
 use common::*;
 use quests_protocol::definitions::*;
-use quests_server::api::routes::ErrorResponse;
+use quests_server::api::routes::{quests::CreateQuestRequest, ErrorResponse};
 
 #[actix_web::test]
 async fn create_quest_should_be_200() {
@@ -38,14 +38,13 @@ async fn create_quest_should_be_200() {
 async fn create_quest_should_be_400_quest_validation_error() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
-    let quest_definition = Quest {
-        id: "3e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![],
             steps: vec![],
-        }),
+        },
     };
 
     let headers = get_signed_headers(
@@ -79,14 +78,13 @@ async fn create_quest_should_be_400_quest_validation_error() {
 async fn create_quest_should_be_401() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
-    let quest_definition = Quest {
-        id: "4e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![],
             steps: vec![],
-        }),
+        },
     };
 
     let req = TestRequest::post()

--- a/crates/server/tests/deactivate_quest.rs
+++ b/crates/server/tests/deactivate_quest.rs
@@ -15,6 +15,7 @@ async fn deactivate_quest_should_be_200() {
         .unwrap();
 
     let quest_definition = Quest {
+        id: "5e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {
@@ -102,6 +103,7 @@ async fn deactivate_quest_should_be_403() {
         .unwrap();
 
     let quest_definition = Quest {
+        id: "6e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {

--- a/crates/server/tests/deactivate_quest.rs
+++ b/crates/server/tests/deactivate_quest.rs
@@ -5,6 +5,7 @@ pub use common::*;
 use quests_db::core::definitions::{CreateQuest, QuestsDatabase};
 use quests_db::create_quests_db_component;
 use quests_protocol::definitions::*;
+use quests_server::api::routes::quests::CreateQuestRequest;
 use quests_server::api::routes::ErrorResponse;
 
 #[actix_web::test]
@@ -14,14 +15,13 @@ async fn deactivate_quest_should_be_200() {
         .await
         .unwrap();
 
-    let quest_definition = Quest {
-        id: "5e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![], // not needed for this test
             steps: vec![],       // not needed for this test
-        }),
+        },
     };
 
     let create_quest = CreateQuest {
@@ -102,14 +102,13 @@ async fn deactivate_quest_should_be_403() {
         .await
         .unwrap();
 
-    let quest_definition = Quest {
-        id: "6e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![], // not needed for this test
             steps: vec![],       // not needed for this test
-        }),
+        },
     };
 
     let create_quest = CreateQuest {

--- a/crates/server/tests/update_quest.rs
+++ b/crates/server/tests/update_quest.rs
@@ -31,6 +31,7 @@ async fn update_quest_should_be_200() {
         .unwrap();
 
     let quest_update = Quest {
+        id: "5f9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1_UPDATE".to_string(),
         description: "Grab some apples - Updated".to_string(),
         definition: Some(QuestDefinition {
@@ -129,6 +130,7 @@ async fn update_quest_should_be_400_uuid_bad_format() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
     let quest_definition = Quest {
+        id: "7e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {
@@ -213,6 +215,7 @@ async fn update_quest_should_be_400_quest_validation_error() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
     let quest_definition = Quest {
+        id: "8e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {
@@ -263,6 +266,7 @@ async fn update_quest_should_be_401() {
     let app = init_service(build_app(&config).await).await;
 
     let quest_update = Quest {
+        id: "9e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1_UPDATE".to_string(),
         description: "Grab some apples - Updated".to_string(),
         definition: Some(QuestDefinition {
@@ -347,6 +351,7 @@ async fn update_quest_should_be_403() {
     let id = db.create_quest(&create_quest, "0xA").await.unwrap();
 
     let quest_update = Quest {
+        id: "0e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1_UPDATE".to_string(),
         description: "Grab some apples - Updated".to_string(),
         definition: Some(QuestDefinition {

--- a/crates/server/tests/update_quest.rs
+++ b/crates/server/tests/update_quest.rs
@@ -6,7 +6,7 @@ use quests_db::core::definitions::{CreateQuest, QuestsDatabase};
 use quests_db::create_quests_db_component;
 use quests_protocol::definitions::*;
 use quests_protocol::quests::Coordinates;
-use quests_server::api::routes::quests::UpdateQuestResponse;
+use quests_server::api::routes::quests::{CreateQuestRequest, UpdateQuestResponse};
 use quests_server::api::routes::ErrorResponse;
 
 #[actix_web::test]
@@ -30,11 +30,10 @@ async fn update_quest_should_be_200() {
         .await
         .unwrap();
 
-    let quest_update = Quest {
-        id: "5f9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_update = CreateQuestRequest {
         name: "QUEST-1_UPDATE".to_string(),
         description: "Grab some apples - Updated".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![
                 Connection::new("A-Updated", "B"),
                 Connection::new("B", "C"),
@@ -78,7 +77,7 @@ async fn update_quest_should_be_200() {
                     description: "".to_string(),
                 },
             ],
-        }),
+        },
     };
 
     let path = format!("/quests/{}", id);
@@ -112,28 +111,21 @@ async fn update_quest_should_be_200() {
     assert_eq!(quest_updated.name, "QUEST-1_UPDATE");
     assert_eq!(quest_updated.description, "Grab some apples - Updated");
     let definition = QuestDefinition::decode(quest_updated.definition.as_slice()).unwrap();
-    assert_eq!(
-        quest_update.definition.as_ref().unwrap().steps.len(),
-        definition.steps.len()
-    );
-    for step in &quest_update.definition.as_ref().unwrap().steps {
+    assert_eq!(quest_update.definition.steps.len(), definition.steps.len());
+    for step in &quest_update.definition.steps {
         assert!(definition.steps.iter().any(|s| s.id == step.id));
     }
-    assert_eq!(
-        quest_update.definition.as_ref().unwrap().connections,
-        definition.connections
-    );
+    assert_eq!(quest_update.definition.connections, definition.connections);
 }
 
 #[actix_web::test]
 async fn update_quest_should_be_400_uuid_bad_format() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
-    let quest_definition = Quest {
-        id: "7e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![
                 Connection::new("A", "B"),
                 Connection::new("B", "C"),
@@ -177,10 +169,10 @@ async fn update_quest_should_be_400_uuid_bad_format() {
                     description: "".to_string(),
                 },
             ],
-        }),
+        },
     };
 
-    let quest_update = Quest {
+    let quest_update = CreateQuestRequest {
         name: "QUEST-1_UPDATE".to_string(),
         ..quest_definition
     };
@@ -214,17 +206,16 @@ async fn update_quest_should_be_400_uuid_bad_format() {
 async fn update_quest_should_be_400_quest_validation_error() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
-    let quest_definition = Quest {
-        id: "8e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![], // not needed for test
             steps: vec![],       // not needed for this test
-        }),
+        },
     };
 
-    let quest_update = Quest {
+    let quest_update = CreateQuestRequest {
         name: "QUEST-1_UPDATE".to_string(),
         ..quest_definition
     };
@@ -265,11 +256,10 @@ async fn update_quest_should_be_401() {
     let config = get_configuration().await;
     let app = init_service(build_app(&config).await).await;
 
-    let quest_update = Quest {
-        id: "9e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_update = CreateQuestRequest {
         name: "QUEST-1_UPDATE".to_string(),
         description: "Grab some apples - Updated".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![
                 Connection::new("A-Updated", "B"),
                 Connection::new("B", "C"),
@@ -313,7 +303,7 @@ async fn update_quest_should_be_401() {
                     description: "".to_string(),
                 },
             ],
-        }),
+        },
     };
 
     let path = format!("/quests/{}", uuid::Uuid::new_v4());
@@ -350,11 +340,10 @@ async fn update_quest_should_be_403() {
 
     let id = db.create_quest(&create_quest, "0xA").await.unwrap();
 
-    let quest_update = Quest {
-        id: "0e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
+    let quest_update = CreateQuestRequest {
         name: "QUEST-1_UPDATE".to_string(),
         description: "Grab some apples - Updated".to_string(),
-        definition: Some(QuestDefinition {
+        definition: QuestDefinition {
             connections: vec![
                 Connection::new("A-Updated", "B"),
                 Connection::new("B", "C"),
@@ -398,7 +387,7 @@ async fn update_quest_should_be_403() {
                     description: "".to_string(),
                 },
             ],
-        }),
+        },
     };
 
     let path = format!("/quests/{}", id);

--- a/crates/system/src/event_processing.rs
+++ b/crates/system/src/event_processing.rs
@@ -114,7 +114,7 @@ impl EventProcessor {
             {
                 Ok(ApplyEventResult::NewState(quest_state)) => {
                     match self
-                        .add_event_and_notify(event, &quest_instance, quest, quest_state)
+                        .add_event_and_notify(event, &quest_instance, quest_state)
                         .await
                     {
                         Ok(_) => event_applied_to_instances += 1,
@@ -146,7 +146,6 @@ impl EventProcessor {
         self: &Arc<Self>,
         event: &Event,
         quest_instance: &QuestInstance,
-        quest: Quest,
         quest_state: QuestState,
     ) -> Result<(), ProcessEventError> {
         debug!("Processing event > event applied with new state: {quest_state:?}");
@@ -171,12 +170,8 @@ impl EventProcessor {
         self.quests_channel
             .publish(UserUpdate {
                 message: Some(user_update::Message::QuestStateUpdate(QuestStateUpdate {
-                    quest_data: Some(QuestStateWithData {
-                        name: quest.name,
-                        description: quest.description,
-                        quest_instance_id: quest_instance.id.clone(),
-                        quest_state: Some(quest_state),
-                    }),
+                    instance_id: quest_instance.id.clone(),
+                    quest_state: Some(quest_state),
                     event_id: event.id.clone(),
                 })),
             })
@@ -191,6 +186,7 @@ impl EventProcessor {
 
         let quest_definition = QuestDefinition::decode(&*quest.definition)?;
         let quest = Quest {
+            id: quest.id,
             name: quest.name,
             description: quest.description,
             definition: Some(quest_definition),

--- a/crates/system/tests/event_processing.rs
+++ b/crates/system/tests/event_processing.rs
@@ -21,6 +21,7 @@ async fn can_process_events() {
         .expect("can create db");
 
     let quest_definition = Quest {
+        id: "1e9a8bbf-2223-4f51-b7e5-660d35cedef4".to_string(),
         name: "QUEST-1".to_string(),
         description: "Grab some apples".to_string(),
         definition: Some(QuestDefinition {

--- a/docs/quests.proto
+++ b/docs/quests.proto
@@ -113,28 +113,35 @@ message QuestState {
   repeated string required_steps = 5;
 }
 
-message QuestStateWithData {
-  string quest_instance_id = 1;
+message Quest {
+  string id = 1;
   string name = 2;
   string description = 3;
-  QuestState quest_state = 4;
+  QuestDefinition definition = 4;
+}
+
+message QuestInstance {
+  string id = 1;
+  Quest quest = 2;
+  QuestState state = 3;
 }
 
 message QuestStateUpdate {
-  QuestStateWithData quest_data = 1;
-  string event_id = 2;
+  string instance_id = 1;
+  QuestState quest_state = 2;
+  string event_id = 3;
 }
 
 message UserUpdate {
   oneof message {
     QuestStateUpdate quest_state_update = 1;
-    QuestStateWithData new_quest_started = 2;
+    QuestInstance new_quest_started = 2;
     fixed32 event_ignored = 4;
   }
 }
 
 message Quests {
-  repeated QuestInstance quests = 1;
+  repeated QuestInstance instances = 1;
 }
 
 message GetAllQuestsResponse {
@@ -142,12 +149,6 @@ message GetAllQuestsResponse {
     Quests quests = 1;
     InternalServerError internal_server_error = 2;
   }
-}
-
-message Quest {
-  string name = 1;
-  string description = 2;
-  QuestDefinition definition = 3;
 }
 
 message GetQuestDefinitionRequest {
@@ -159,12 +160,6 @@ message GetQuestDefinitionResponse {
     Quest quest = 1;
     InternalServerError internal_server_error = 2;
   }
-}
-
-message QuestInstance {
-  string instance_id = 1;
-  Quest quest = 2;
-  QuestState state = 3;
 }
 
 service QuestsService {


### PR DESCRIPTION
## Description

Include relevant information when sending updates to the client:

- Quest includes its ID
- GetAllQuests: QuestInstace list
- Subscribe:
   - New quest started: QuestInstance now includes QuestDefinition
   - Quest Update: instance ID, QuestState

Closes #120