### PR TITLE
feat: add QuestAlreadyStarted message response

### DIFF
--- a/crates/protocol/src/quests/builders.rs
+++ b/crates/protocol/src/quests/builders.rs
@@ -79,34 +79,37 @@ impl Action {
 }
 
 impl StartQuestResponse {
-    pub fn accepted() -> Self {
+    fn response(response: start_quest_response::Response) -> Self {
         Self {
-            response: Some(start_quest_response::Response::Accepted(
-                start_quest_response::Accepted {},
-            )),
+            response: Some(response),
         }
+    }
+    pub fn accepted() -> Self {
+        Self::response(start_quest_response::Response::Accepted(
+            start_quest_response::Accepted {},
+        ))
     }
 
     pub fn invalid_quest() -> Self {
-        Self {
-            response: Some(start_quest_response::Response::InvalidQuest(
-                InvalidQuest {},
-            )),
-        }
+        Self::response(start_quest_response::Response::InvalidQuest(
+            InvalidQuest {},
+        ))
     }
 
     pub fn not_uuid_error() -> Self {
-        Self {
-            response: Some(start_quest_response::Response::NotUuidError(NotUuid {})),
-        }
+        Self::response(start_quest_response::Response::NotUuidError(NotUuid {}))
+    }
+
+    pub fn quest_already_started() -> Self {
+        Self::response(start_quest_response::Response::QuestAlreadyStarted(
+            QuestAlreadyStarted {},
+        ))
     }
 
     pub fn internal_server_error() -> Self {
-        Self {
-            response: Some(start_quest_response::Response::InternalServerError(
-                InternalServerError {},
-            )),
-        }
+        Self::response(start_quest_response::Response::InternalServerError(
+            InternalServerError {},
+        ))
     }
 }
 

--- a/crates/server/src/rpc/service.rs
+++ b/crates/server/src/rpc/service.rs
@@ -80,6 +80,9 @@ impl QuestsServiceServer<QuestsRpcServerContext, ServiceErrors> for QuestsServic
                 log::error!("QuestsServiceImplementation > StartQuest Error > {err:?}");
                 match err {
                     QuestError::NotFoundOrInactive => Ok(StartQuestResponse::invalid_quest()),
+                    QuestError::QuestAlreadyStarted => {
+                        Ok(StartQuestResponse::quest_already_started())
+                    }
                     QuestError::CommonError(CommonError::NotUUID) => {
                         Ok(StartQuestResponse::not_uuid_error())
                     }

--- a/docs/quests.proto
+++ b/docs/quests.proto
@@ -13,6 +13,8 @@ message InternalServerError {}
 
 message NotFoundQuestInstance {}
 
+message QuestAlreadyStarted {}
+
 message NotOwner {}
 
 message IgnoredEvent {}
@@ -33,6 +35,7 @@ message StartQuestResponse {
     InvalidQuest invalid_quest = 2;
     NotUUID not_uuid_error = 3;
     InternalServerError internal_server_error = 4;
+    QuestAlreadyStarted quest_already_started = 5;
   }
 }
 


### PR DESCRIPTION
## Description

Before this PR, when trying to start a quest that was already started, it returns an `Internal server error`.
Now it sends the correct message response.

Closes  #119