### PR TITLE
refactor: hide action items from public quest definitions and quest states

### DIFF
--- a/crates/protocol/src/quests/mod.rs
+++ b/crates/protocol/src/quests/mod.rs
@@ -65,11 +65,10 @@ impl Quest {
 
     pub fn hide_actions(&mut self) {
         self.definition.as_mut().map(|definition| {
-            definition.steps.iter_mut().for_each(|step| {
-                step.tasks
-                    .iter_mut()
-                    .for_each(|task| task.action_items.clear())
-            });
+            definition
+                .steps
+                .iter_mut()
+                .for_each(|step| step.tasks.iter_mut().for_each(|task| task.hide_actions()));
         });
     }
 }
@@ -245,6 +244,28 @@ impl QuestDefinition {
         }
 
         steps
+    }
+}
+
+impl QuestState {
+    pub fn hide_actions(&mut self) {
+        for (_, step) in &mut self.current_steps {
+            step.hide_actions();
+        }
+    }
+}
+
+impl StepContent {
+    pub fn hide_actions(&mut self) {
+        for task in &mut self.to_dos {
+            task.hide_actions();
+        }
+    }
+}
+
+impl Task {
+    pub fn hide_actions(&mut self) {
+        self.action_items.clear();
     }
 }
 

--- a/crates/protocol/src/quests/mod.rs
+++ b/crates/protocol/src/quests/mod.rs
@@ -62,6 +62,16 @@ impl Quest {
         };
         definition.is_valid()
     }
+
+    pub fn hide_actions(&mut self) {
+        self.definition.as_mut().map(|definition| {
+            definition.steps.iter_mut().for_each(|step| {
+                step.tasks
+                    .iter_mut()
+                    .for_each(|task| task.action_items.clear())
+            });
+        });
+    }
 }
 
 impl QuestDefinition {

--- a/crates/system/src/event_processing.rs
+++ b/crates/system/src/event_processing.rs
@@ -143,7 +143,7 @@ impl EventProcessor {
         event: &Event,
         quest_id: &str,
         quest_instance_id: &str,
-        quest_state: QuestState,
+        mut quest_state: QuestState,
     ) -> Result<(), ProcessEventError> {
         debug!("Processing event > event applied with new state: {quest_state:?}");
         let add_event = AddEvent {
@@ -165,6 +165,7 @@ impl EventProcessor {
             give_rewards_to_user(self.database.clone(), quest_id, &event.address).await;
         }
 
+        quest_state.hide_actions();
         self.quests_channel
             .publish(UserUpdate {
                 message: Some(user_update::Message::QuestStateUpdate(QuestStateUpdate {


### PR DESCRIPTION
## Description

Do not expose task action items on the public quest definitions and quest state notifications.