### PR TITLE
fix: updatable rewards

### DIFF
--- a/crates/db/src/core/definitions.rs
+++ b/crates/db/src/core/definitions.rs
@@ -12,13 +12,6 @@ pub trait QuestsDatabase: Send + Sync + CloneDatabase {
     async fn ping(&self) -> bool;
 
     async fn create_quest(&self, quest: &CreateQuest, creator_address: &str) -> DBResult<String>;
-    async fn create_quest_with_reward(
-        &self,
-        quest: &CreateQuest,
-        creator_address: &str,
-        hook: &QuestRewardHook,
-        items: &[QuestRewardItem],
-    ) -> DBResult<String>;
     async fn update_quest(
         &self,
         previous_quest_id: &str,
@@ -135,6 +128,7 @@ pub struct CreateQuest<'a> {
     pub description: &'a str,
     pub image_url: &'a str,
     pub definition: Vec<u8>,
+    pub reward: Option<QuestReward>,
 }
 
 #[derive(Default, PartialEq, Serialize, Deserialize, Clone, Debug)]
@@ -147,6 +141,12 @@ pub struct StoredQuest {
     pub image_url: String,
     pub active: bool,
     pub created_at: i64,
+}
+
+#[derive(Default, PartialEq, Serialize, Deserialize, Clone, Debug, ToSchema)]
+pub struct QuestReward {
+    pub hook: QuestRewardHook,
+    pub items: Vec<QuestRewardItem>,
 }
 
 #[derive(Default, PartialEq, Serialize, Deserialize, Clone, Debug, ToSchema)]

--- a/crates/db/tests/db_works.rs
+++ b/crates/db/tests/db_works.rs
@@ -25,6 +25,7 @@ async fn quests_database_works() {
             description: "Talk to a NPC",
             definition: vec![0, 1, 4],
             image_url: "",
+            reward: None,
         },
     )
     .await;

--- a/crates/server/src/api/routes/api_doc.rs
+++ b/crates/server/src/api/routes/api_doc.rs
@@ -33,7 +33,6 @@ use utoipa_redoc::Servable;
                 schemas(
                         quests::create_quest::CreateQuestRequest,
                         quests::create_quest::CreateQuestResponse,
-                        quests::create_quest::QuestReward,
                         quests::get_quest::GetQuestResponse,
                         quests::get_quests::GetQuestsQuery,
                         quests::get_quests::GetQuestsResponse,
@@ -49,8 +48,7 @@ use utoipa_redoc::Servable;
                         quests_protocol::definitions::Task,
                         quests_protocol::definitions::Action,
                         quests_protocol::definitions::Connection,
-                        quests_db::core::definitions::QuestRewardHook,
-                        quests_db::core::definitions::QuestRewardItem,
+                        quests_db::core::definitions::QuestReward,
 
                 )
         ),

--- a/crates/server/src/domain/types.rs
+++ b/crates/server/src/domain/types.rs
@@ -29,28 +29,3 @@ impl ToQuest for StoredQuest {
         })
     }
 }
-
-impl ToCreateQuest for Quest {
-    fn to_create_quest(&self) -> Result<CreateQuest, QuestError> {
-        let Quest {
-            name,
-            description,
-            definition,
-            image_url,
-            ..
-        } = self;
-
-        let Some(definition) = definition else {
-            return Err(QuestError::QuestValidation(
-                "Quest definition not present".to_string(),
-            ));
-        };
-
-        Ok(CreateQuest {
-            name,
-            description,
-            image_url,
-            definition: definition.encode_to_vec(),
-        })
-    }
-}

--- a/crates/server/tests/common/rewards.rs
+++ b/crates/server/tests/common/rewards.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-use quests_db::core::definitions::{QuestRewardHook, QuestRewardItem};
-use quests_server::api::routes::quests::QuestReward;
+use quests_db::core::definitions::{QuestReward, QuestRewardHook, QuestRewardItem};
 
 fn create_reward_hook() -> QuestRewardHook {
     let mut request_body = HashMap::new();

--- a/crates/server/tests/create_quest.rs
+++ b/crates/server/tests/create_quest.rs
@@ -5,14 +5,14 @@ use actix_web_lab::__reexports::serde_json;
 use common::*;
 use quests_db::{
     core::{
-        definitions::{QuestRewardHook, QuestRewardItem, QuestsDatabase},
+        definitions::{QuestReward, QuestRewardHook, QuestRewardItem, QuestsDatabase},
         errors::DBError,
     },
     create_quests_db_component,
 };
 use quests_protocol::definitions::*;
 use quests_server::api::routes::{
-    quests::{CreateQuestRequest, CreateQuestResponse, QuestReward},
+    quests::{CreateQuestRequest, CreateQuestResponse},
     ErrorResponse,
 };
 use std::collections::HashMap;

--- a/crates/server/tests/deactivate_quest.rs
+++ b/crates/server/tests/deactivate_quest.rs
@@ -31,6 +31,7 @@ async fn deactivate_quest_should_be_200() {
         description: &quest_definition.description,
         image_url: &quest_definition.image_url,
         definition: vec![],
+        reward: None,
     };
 
     let id = db
@@ -121,6 +122,7 @@ async fn deactivate_quest_should_be_403() {
         description: &quest_definition.description,
         image_url: &quest_definition.image_url,
         definition: vec![],
+        reward: None,
     };
 
     let id = db.create_quest(&create_quest, "0xA").await.unwrap();

--- a/crates/server/tests/get_quest.rs
+++ b/crates/server/tests/get_quest.rs
@@ -27,6 +27,7 @@ async fn get_quest_with_defintiions_should_be_200() {
             .as_ref()
             .unwrap()
             .encode_to_vec(),
+        reward: None,
     };
 
     let id = db
@@ -96,6 +97,7 @@ async fn get_quest_without_defintiions_should_be_200() {
             .as_ref()
             .unwrap()
             .encode_to_vec(),
+        reward: None,
     };
 
     let id = db

--- a/crates/server/tests/get_quest_rewards.rs
+++ b/crates/server/tests/get_quest_rewards.rs
@@ -34,6 +34,7 @@ async fn get_quest_rewards_should_be_200() {
                 description: &description,
                 definition: definition.unwrap().encode_to_vec(),
                 image_url: "",
+                reward: None,
             },
             "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5", // identity address
         )
@@ -85,6 +86,7 @@ async fn quest_has_no_rewards() {
                 description: &description,
                 definition: definition.unwrap().encode_to_vec(),
                 image_url: "",
+                reward: None,
             },
             "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5", // identity address
         )

--- a/crates/server/tests/get_quest_stats.rs
+++ b/crates/server/tests/get_quest_stats.rs
@@ -31,6 +31,7 @@ async fn get_quest_stats_should_be_200() {
                 description: &description,
                 definition: definition.unwrap().encode_to_vec(),
                 image_url: "",
+                reward: None,
             },
             "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5", // identity address
         )
@@ -93,6 +94,7 @@ async fn get_quest_stats_should_be_403() {
                 description: &description,
                 definition: definition.unwrap().encode_to_vec(),
                 image_url: "",
+                reward: None,
             },
             "0xB",
         )
@@ -144,6 +146,7 @@ async fn get_quest_stats_should_be_401() {
                 description: &description,
                 definition: definition.unwrap().encode_to_vec(),
                 image_url: "",
+                reward: None,
             },
             "0xB",
         )

--- a/crates/server/tests/get_quests.rs
+++ b/crates/server/tests/get_quests.rs
@@ -23,6 +23,7 @@ async fn get_quests_should_be_200() {
         definition: quest_definition.definition.unwrap().encode_to_vec(),
         description: &quest_definition.description,
         image_url: &quest_definition.image_url,
+        reward: None,
     };
 
     db.create_quest(&quest, "0xA").await.unwrap();

--- a/crates/server/tests/update_quest.rs
+++ b/crates/server/tests/update_quest.rs
@@ -24,6 +24,7 @@ async fn update_quest_should_be_200() {
         description: &quest.description,
         image_url: &quest.image_url,
         definition: quest.definition.as_ref().unwrap().encode_to_vec(),
+        reward: None,
     };
 
     let id = db
@@ -346,6 +347,7 @@ async fn update_quest_should_be_403() {
         description: &quest.description,
         image_url: &quest.image_url,
         definition: quest.definition.as_ref().unwrap().encode_to_vec(),
+        reward: None,
     };
 
     let id = db.create_quest(&create_quest, "0xA").await.unwrap();

--- a/crates/system/tests/event_processing.rs
+++ b/crates/system/tests/event_processing.rs
@@ -85,6 +85,7 @@ async fn can_process_events() {
             .as_ref()
             .unwrap()
             .encode_to_vec(),
+        reward: None,
     };
 
     let result = db.create_quest(&create_quest, "0xA").await;
@@ -183,6 +184,7 @@ async fn should_call_rewards_hook_when_user_completes_a_quest() {
             .as_ref()
             .unwrap()
             .encode_to_vec(),
+        reward: None,
     };
 
     let quest_id = db.create_quest(&create_quest, "0xA").await.unwrap();


### PR DESCRIPTION
This PR:
- fixes a bug when updating an existing Quest. Quest's Rewards were not being updated. 