### PR TITLE
fix: record metrics properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,18 +273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-web-prom"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df3127d20a5d01c9fc9aceb969a38d31a6767e1b48a54d55a8f56c769a84923"
-dependencies = [
- "actix-web",
- "futures-core",
- "pin-project-lite",
- "prometheus",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +866,17 @@ dependencies = [
  "log",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "dcl-http-prom-metrics"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83271526f6ec17498f8bc85c256913357bc78f8050dd847422d9e90cb9f619af"
+dependencies = [
+ "actix-web",
+ "actix-web-lab",
+ "prometheus",
 ]
 
 [[package]]
@@ -2667,11 +2666,11 @@ dependencies = [
  "actix-cors",
  "actix-web",
  "actix-web-lab",
- "actix-web-prom",
  "async-trait",
  "config",
  "dcl-crypto",
  "dcl-crypto-middleware-rs",
+ "dcl-http-prom-metrics",
  "dcl-rpc",
  "derive_more",
  "env_logger",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -17,7 +17,7 @@ log = { workspace = true }
 dcl-crypto = { workspace = true }
 uuid = { workspace = true }
 
-actix-web-prom = "0.6.0"
+dcl-http-prom-metrics = "0.1.0"
 async-trait = "0.1.57"
 tracing = "0.1"
 tracing-log = "0.1"

--- a/crates/server/src/api/middlewares/metrics.rs
+++ b/crates/server/src/api/middlewares/metrics.rs
@@ -1,8 +1,0 @@
-use actix_web_prom::{PrometheusMetrics, PrometheusMetricsBuilder};
-
-pub fn metrics() -> PrometheusMetrics {
-    PrometheusMetricsBuilder::new("dcl_quests")
-        .endpoint("/metrics")
-        .build()
-        .unwrap()
-}

--- a/crates/server/src/api/middlewares/mod.rs
+++ b/crates/server/src/api/middlewares/mod.rs
@@ -1,9 +1,7 @@
 mod auth;
-mod metrics;
 mod metrics_token;
 mod tracing;
 
 pub use self::tracing::initialize_telemetry;
 pub use auth::dcl_auth_middleware;
-pub use metrics::metrics;
 pub use metrics_token::metrics_token;

--- a/crates/server/src/configuration.rs
+++ b/crates/server/src/configuration.rs
@@ -34,7 +34,7 @@ impl Config {
             .set_default("http_server_port", 3000)? // It's empty for local development
             .set_default("ws_server_port", 3001)? // default for local development
             .set_default("env", "dev")?
-            .set_default("wkc_metrics_bearer_token", "")?
+            .set_default("wkc_metrics_bearer_token", "DEV")?
             .set_default(
                 "database_url",
                 "postgres://postgres:postgres@localhost:5432/quests_db",

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -9,6 +9,7 @@ use actix_web::web::Data;
 use actix_web::App;
 use actix_web_lab::__reexports::serde_json;
 use dcl_crypto::Identity;
+use dcl_http_prom_metrics::HttpMetricsCollectorBuilder;
 use quests_db::core::ops::{Connect, GetConnection, Migrate};
 use quests_db::{create_quests_db_component, DatabaseOptions, Executor};
 use quests_message_broker::messages_queue::RedisMessagesQueue;
@@ -49,6 +50,7 @@ pub async fn build_app(
         &Data::new(config.clone()),
         &Data::new(db),
         &Data::new(events_queue),
+        &Data::new(HttpMetricsCollectorBuilder::default().build()),
     )
 }
 


### PR DESCRIPTION
This PR:
- fixes 404 metric recording
- fixes de-synced metrics on each GET to /metrics