### PR TITLE
feat: state management for creators

### DIFF
--- a/crates/db/src/core/definitions.rs
+++ b/crates/db/src/core/definitions.rs
@@ -21,6 +21,7 @@ pub trait QuestsDatabase: Send + Sync + CloneDatabase {
     async fn deactivate_quest(&self, id: &str) -> DBResult<String>;
     async fn get_quest(&self, id: &str) -> DBResult<StoredQuest>;
     async fn get_active_quests(&self, offset: i64, limit: i64) -> DBResult<Vec<StoredQuest>>;
+    async fn count_active_quests(&self) -> DBResult<i64>;
     async fn get_quests_by_creator_address(
         &self,
         creator_address: &str,
@@ -64,7 +65,7 @@ pub trait QuestsDatabase: Send + Sync + CloneDatabase {
 
     async fn add_event(&self, event: &AddEvent, quest_instance_id: &str) -> DBResult<()>;
     async fn get_events(&self, quest_instance_id: &str) -> DBResult<Vec<Event>>;
-    async fn remove_events(&self, quest_instance_id: &str) -> DBResult<()>;
+    async fn remove_events_from_quest_instance(&self, quest_instance_id: &str) -> DBResult<()>;
     async fn remove_event(&self, event_id: &str) -> DBResult<()>;
 
     async fn add_reward_hook_to_quest(

--- a/crates/db/src/core/definitions.rs
+++ b/crates/db/src/core/definitions.rs
@@ -21,12 +21,13 @@ pub trait QuestsDatabase: Send + Sync + CloneDatabase {
     async fn deactivate_quest(&self, id: &str) -> DBResult<String>;
     async fn get_quest(&self, id: &str) -> DBResult<StoredQuest>;
     async fn get_active_quests(&self, offset: i64, limit: i64) -> DBResult<Vec<StoredQuest>>;
-    async fn get_quests_by_creator_id(
+    async fn get_quests_by_creator_address(
         &self,
-        creator_id: &str,
+        creator_address: &str,
         offset: i64,
         limit: i64,
     ) -> DBResult<Vec<StoredQuest>>;
+    async fn count_quests_by_creator_address(&self, creator_address: &str) -> DBResult<i64>;
     async fn is_active_quest(&self, quest_id: &str) -> DBResult<bool>;
     async fn has_active_quest_instance(&self, user_address: &str, quest_id: &str)
         -> DBResult<bool>;
@@ -59,10 +60,12 @@ pub trait QuestsDatabase: Send + Sync + CloneDatabase {
         offset: i64,
         limit: i64,
     ) -> DBResult<Vec<QuestInstance>>;
+    async fn count_active_quest_instances_by_quest_id(&self, quest_id: &str) -> DBResult<i64>;
 
     async fn add_event(&self, event: &AddEvent, quest_instance_id: &str) -> DBResult<()>;
     async fn get_events(&self, quest_instance_id: &str) -> DBResult<Vec<Event>>;
     async fn remove_events(&self, quest_instance_id: &str) -> DBResult<()>;
+    async fn remove_event(&self, event_id: &str) -> DBResult<()>;
 
     async fn add_reward_hook_to_quest(
         &self,

--- a/crates/db/src/core/errors.rs
+++ b/crates/db/src/core/errors.rs
@@ -93,6 +93,9 @@ pub enum DBError {
     #[error("Unable to count active quest instances: {0}")]
     UnableToCountActiveQuestInstances(BoxDynError),
 
+    #[error("Unable to count active quests: {0}")]
+    UnableToCountActiveQuests(BoxDynError),
+
     #[error("Unable to check quest creator: {0}")]
     UnableToCheckQuestCreator(BoxDynError),
 

--- a/crates/db/src/core/errors.rs
+++ b/crates/db/src/core/errors.rs
@@ -58,6 +58,9 @@ pub enum DBError {
     #[error("Unable to retrieve all instances related to Quest ID {0}: {1}")]
     GetQuestInstancesByQuestIdFailed(String, BoxDynError),
 
+    #[error("Unable to retrieve all active instances related to Quest ID {0}: {1}")]
+    GetActiveQuestInstancesByQuestIdFailed(String, BoxDynError),
+
     #[error("Unable to check if a quest instance is still active: {0}")]
     GetActiveQuestInstanceFailed(BoxDynError),
 
@@ -86,6 +89,12 @@ pub enum DBError {
 
     #[error("Unable to check if a quest instance is completed: {0}")]
     IsCompletedInstanceFailed(BoxDynError),
+
+    #[error("Unable to count active quest instances: {0}")]
+    UnableToCountActiveQuestInstances(BoxDynError),
+
+    #[error("Unable to check quest creator: {0}")]
+    UnableToCheckQuestCreator(BoxDynError),
 
     #[error("Row has incorrect data: {0}")]
     RowCorrupted(BoxDynError),

--- a/crates/db/src/core/tests.rs
+++ b/crates/db/src/core/tests.rs
@@ -9,6 +9,10 @@ pub async fn quest_database_works<DB: QuestsDatabase>(db: &DB, quest: CreateQues
     assert!(db.ping().await);
     let quest_id = db.create_quest(&quest, "0xA").await.unwrap();
 
+    let count_active_quest = db.count_active_quests().await.unwrap();
+
+    assert_eq!(count_active_quest, 1);
+
     let is_creator = db.is_quest_creator(&quest_id, "0xA").await.unwrap();
     assert!(is_creator);
 
@@ -298,7 +302,9 @@ pub async fn quest_database_works<DB: QuestsDatabase>(db: &DB, quest: CreateQues
     assert!(is_completed);
 
     // test remove events
-    db.remove_events(&new_quest_instance_id).await.unwrap();
+    db.remove_events_from_quest_instance(&new_quest_instance_id)
+        .await
+        .unwrap();
     let events = db.get_events(&new_quest_instance_id).await.unwrap();
     assert_eq!(events.len(), 0);
 

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -39,8 +39,8 @@ pub async fn run_server(
 
 pub fn get_app_router(
     config: &Data<Config>,
-    db: &Data<Database>,
-    redis: &Data<RedisMessagesQueue>,
+    database: &Data<Database>,
+    events_queue: &Data<RedisMessagesQueue>,
     metrics_collector: &Data<HttpMetricsCollector>,
 ) -> App<
     impl ServiceFactory<
@@ -57,8 +57,8 @@ pub fn get_app_router(
         .app_data(json_extractor_config())
         .app_data(path_extractor_config())
         .app_data(config.clone())
-        .app_data(db.clone())
-        .app_data(redis.clone())
+        .app_data(database.clone())
+        .app_data(events_queue.clone())
         .app_data(metrics_collector.clone())
         .wrap(dcl_http_prom_metrics::metrics())
         .wrap(middlewares::metrics_token(&config.wkc_metrics_bearer_token))

--- a/crates/server/src/api/routes/api_doc.rs
+++ b/crates/server/src/api/routes/api_doc.rs
@@ -30,7 +30,10 @@ use utoipa_redoc::Servable;
                 quests::get_quest_instances,
                 creators::get_quests_by_creator_id,
                 quest_instances::reset_quest_instance,
-                quest_instances::get_quest_instance_state
+                quest_instances::get_quest_instance_state,
+                quest_instances::add_event_to_instance,
+                quest_instances::get_quest_instance,
+                quest_instances::remove_event_from_instance,
         ),
         components(
                 schemas(
@@ -61,7 +64,10 @@ use utoipa_redoc::Servable;
                         quests_db::core::definitions::QuestInstance,
                         quest_instances::state::GetInstanceStateResponse,
                         quests::get_instances::GetQuestInstancesResponse,
-                        quests::get_instances::GetQuestInstancesQuery
+                        quests::get_instances::GetQuestInstancesQuery,
+                        quest_instances::add_event::AddEventToInstancePayload,
+                        quest_instances::add_event::AddEventToInstanceResponse,
+                        quest_instances::get::GetQuestInstanceResponse,
                 )
         ),
         tags(

--- a/crates/server/src/api/routes/api_doc.rs
+++ b/crates/server/src/api/routes/api_doc.rs
@@ -56,6 +56,7 @@ use utoipa_redoc::Servable;
                         quests_protocol::definitions::Connection,
                         quests_protocol::definitions::QuestState,
                         quests_protocol::definitions::StepContent,
+                        quests_protocol::definitions::EventRequest,
                         quests_protocol::definitions::Task,
                         quests_db::core::definitions::QuestReward,
                         quests_db::core::definitions::QuestRewardHook,

--- a/crates/server/src/api/routes/quest_instances/add_event.rs
+++ b/crates/server/src/api/routes/quest_instances/add_event.rs
@@ -1,0 +1,68 @@
+use crate::{
+    api::middlewares::RequiredAuthUser,
+    domain::{events::add_event_controller, quests::QuestError},
+};
+use actix_web::{post, web, HttpResponse};
+use quests_db::{core::definitions::QuestsDatabase, Database};
+use quests_message_broker::messages_queue::RedisMessagesQueue;
+use quests_protocol::definitions::EventRequest;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct AddEventToInstancePayload {
+    pub event: EventRequest,
+}
+
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct AddEventToInstanceResponse {
+    pub accepted: bool,
+}
+
+/// Get Quest Instance's state. Allowed for the Quest Creator
+#[utoipa::path(
+  params(
+      ("quest_instance" = String, description = "Quest Instance UUID")
+  ),
+  responses(
+      (status = 200, description = "Event enqueue result", body = AddEventToInstanceResponse),
+      (status = 401, description = "Unauthorized"),
+      (status = 403, description = "Forbidden"),
+      (status = 404, description = "Quest Instance not found"),
+      (status = 500, description = "Internal Server Error")
+  )
+)]
+#[post("/instances/{quest_instance}/events")]
+pub async fn add_event_to_instance(
+    data: web::Data<Database>,
+    events_queue: web::Data<RedisMessagesQueue>,
+    quest_instance: web::Path<String>,
+    event: web::Json<AddEventToInstancePayload>,
+    auth_user: RequiredAuthUser,
+) -> HttpResponse {
+    let db = data.into_inner();
+
+    let RequiredAuthUser { address } = auth_user;
+
+    match db.get_quest_instance(&quest_instance).await {
+        Ok(instance) => match db.is_quest_creator(&instance.quest_id, &address).await {
+            Ok(is_creator) if !is_creator => HttpResponse::from_error(QuestError::NotQuestCreator),
+            Ok(_) => {
+                match add_event_controller(
+                    events_queue.into_inner(),
+                    &instance.user_address,
+                    event.event.to_owned(),
+                )
+                .await
+                {
+                    Ok(_) => HttpResponse::Ok().json(AddEventToInstanceResponse { accepted: true }),
+                    Err(_) => {
+                        HttpResponse::Ok().json(AddEventToInstanceResponse { accepted: false })
+                    }
+                }
+            }
+            Err(err) => HttpResponse::from_error(QuestError::from(err)),
+        },
+        Err(err) => HttpResponse::from_error(QuestError::from(err)),
+    }
+}

--- a/crates/server/src/api/routes/quest_instances/get.rs
+++ b/crates/server/src/api/routes/quest_instances/get.rs
@@ -21,6 +21,7 @@ pub struct GetQuestInstanceResponse {
         (status = 200, description = "Quest Instance", body = GetQuestInstanceResponse),
         (status = 401, description = "Unathorized"),
         (status = 403, description = "Forbidden"),
+        (status = 404, description = "Not Found"),
         (status = 500, description = "Internal Server Error")
     )
 )]

--- a/crates/server/src/api/routes/quest_instances/get.rs
+++ b/crates/server/src/api/routes/quest_instances/get.rs
@@ -1,0 +1,55 @@
+use crate::{api::middlewares::RequiredAuthUser, domain::quests::QuestError};
+use actix_web::{get, web, HttpResponse};
+use quests_db::{
+    core::definitions::{QuestInstance, QuestsDatabase},
+    Database,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Deserialize, Serialize, ToSchema)]
+pub struct GetQuestInstanceResponse {
+    pub instance: QuestInstance,
+}
+
+/// Get a specific quest instance. Only the Quest Creator is allowed to see the Quest Instances
+#[utoipa::path(
+    params(
+        ("quest_instance_id" = String, description = "Quest Instance UUID")
+    ),
+    responses(
+        (status = 200, description = "Quest Instance", body = GetQuestInstanceResponse),
+        (status = 401, description = "Unathorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 500, description = "Internal Server Error")
+    )
+)]
+#[get("/instances/{quest_instance_id}")]
+pub async fn get_quest_instance(
+    db: web::Data<Database>,
+    quest_instance_id: web::Path<String>,
+    auth_user: RequiredAuthUser,
+) -> HttpResponse {
+    let db = db.into_inner();
+    let quest_instance_id = quest_instance_id.into_inner();
+
+    let RequiredAuthUser { address } = auth_user;
+
+    match db.get_quest_instance(&quest_instance_id).await {
+        Ok(instance) => match db.is_quest_creator(&instance.quest_id, &address).await {
+            Ok(is_creator) if !is_creator => HttpResponse::from_error(QuestError::NotQuestCreator),
+            Ok(_) => HttpResponse::Ok().json(GetQuestInstanceResponse { instance }),
+            Err(err) => {
+                log::error!(
+                    "error on checking if {address} is quest creator of {}",
+                    instance.quest_id
+                );
+                HttpResponse::from_error(QuestError::from(err))
+            }
+        },
+        Err(err) => {
+            log::error!("error on getting quest instance {quest_instance_id} : {err}");
+            HttpResponse::from_error(QuestError::from(err))
+        }
+    }
+}

--- a/crates/server/src/api/routes/quest_instances/mod.rs
+++ b/crates/server/src/api/routes/quest_instances/mod.rs
@@ -1,7 +1,13 @@
+pub mod add_event;
+pub mod get;
+pub mod remove_event;
 pub mod reset;
 pub mod state;
 
 use actix_web::Scope;
+pub use add_event::*;
+pub use get::*;
+pub use remove_event::*;
 pub use reset::*;
 pub use state::*;
 
@@ -9,4 +15,7 @@ pub fn services(api_scope: Scope) -> Scope {
     api_scope
         .service(reset_quest_instance)
         .service(get_quest_instance_state)
+        .service(get_quest_instance)
+        .service(add_event_to_instance)
+        .service(remove_event_from_instance)
 }

--- a/crates/server/src/api/routes/quest_instances/remove_event.rs
+++ b/crates/server/src/api/routes/quest_instances/remove_event.rs
@@ -1,0 +1,48 @@
+use crate::{api::middlewares::RequiredAuthUser, domain::quests::QuestError};
+use actix_web::{delete, web, HttpResponse};
+use quests_db::{core::definitions::QuestsDatabase, Database};
+
+/// Get Quest Instance's state. Allowed for the Quest Creator
+#[utoipa::path(
+params(
+    ("quest_instance" = String, description = "Quest Instance UUID")
+),
+responses(
+    (status = 204, description = "Event removed"),
+    (status = 401, description = "Unauthorized"),
+    (status = 403, description = "Forbidden"),
+    (status = 404, description = "Quest Instance not found"),
+    (status = 500, description = "Internal Server Error")
+)
+)]
+#[delete("/instances/{quest_instance}/events/{event_id}")]
+pub async fn remove_event_from_instance(
+    data: web::Data<Database>,
+    path: web::Path<(String, String)>,
+    auth_user: RequiredAuthUser,
+) -> HttpResponse {
+    let db = data.into_inner();
+
+    let (quest_instance_id, event_id) = path.into_inner();
+
+    let RequiredAuthUser { address } = auth_user;
+
+    match db.get_quest_instance(&quest_instance_id).await {
+        Ok(instance) => match db.is_quest_creator(&instance.quest_id, &address).await {
+            Ok(is_creator) if !is_creator => HttpResponse::from_error(QuestError::NotQuestCreator),
+            Ok(_) => match db.remove_event(&event_id).await {
+                // we remove it from completed instance in case it's already completed
+                Ok(_) => match db
+                    .remove_instance_from_completed_instances(&instance.id)
+                    .await
+                {
+                    Ok(_) => HttpResponse::NoContent().finish(),
+                    Err(err) => HttpResponse::from_error(QuestError::from(err)),
+                },
+                Err(err) => HttpResponse::from_error(QuestError::from(err)),
+            },
+            Err(err) => HttpResponse::from_error(QuestError::from(err)),
+        },
+        Err(err) => HttpResponse::from_error(QuestError::from(err)),
+    }
+}

--- a/crates/server/src/api/routes/quest_instances/remove_event.rs
+++ b/crates/server/src/api/routes/quest_instances/remove_event.rs
@@ -11,7 +11,7 @@ responses(
     (status = 204, description = "Event removed"),
     (status = 401, description = "Unauthorized"),
     (status = 403, description = "Forbidden"),
-    (status = 404, description = "Quest Instance not found"),
+    (status = 404, description = "Quest Instance or Event not found"),
     (status = 500, description = "Internal Server Error")
 )
 )]

--- a/crates/server/src/api/routes/quest_instances/reset.rs
+++ b/crates/server/src/api/routes/quest_instances/reset.rs
@@ -45,10 +45,12 @@ async fn reset_quest_instance_controller(
                 }
 
                 // remove events to reset quest instance state
-                db.remove_events(quest_instance_id).await.map_err(|err| {
-                    let err: QuestError = err.into();
-                    err
-                })?;
+                db.remove_events_from_quest_instance(quest_instance_id)
+                    .await
+                    .map_err(|err| {
+                        let err: QuestError = err.into();
+                        err
+                    })?;
 
                 db.remove_instance_from_completed_instances(quest_instance_id)
                     .await

--- a/crates/server/src/api/routes/quests/activate_quest.rs
+++ b/crates/server/src/api/routes/quests/activate_quest.rs
@@ -7,7 +7,7 @@ use quests_db::{core::definitions::QuestsDatabase, Database};
 /// Activates a quest by its ID
 #[utoipa::path(
     params(
-        ("quest_id" = String, description = "ID of the quest to activate")
+        ("quest_id" = String, description = "Quest UUID")
     ),
     responses(
         (status = 202, description = "Quest activated"),

--- a/crates/server/src/api/routes/quests/delete_quest.rs
+++ b/crates/server/src/api/routes/quests/delete_quest.rs
@@ -7,7 +7,7 @@ use quests_db::{core::definitions::QuestsDatabase, Database};
 /// Deactivate a quest
 #[utoipa::path(
     params(
-        ("quest_id" = String, description = "ID of the quest to deactivate")
+        ("quest_id" = String, description = "Quest UUID")
     ),
     responses(
         (status = 202, description = "Quest deactivated"),

--- a/crates/server/src/api/routes/quests/get_instances.rs
+++ b/crates/server/src/api/routes/quests/get_instances.rs
@@ -26,7 +26,7 @@ pub struct GetQuestInstancesResponse {
         ("quest_id" = String, description = "Quest UUID")
     ),
     responses(
-        (status = 200, description = "Quest's Instances", body = GetQuestInstacesResponse),
+        (status = 200, description = "Quest's Instances", body = GetQuestInstancesResponse),
         (status = 401, description = "Unathorized"),
         (status = 403, description = "Forbidden"),
         (status = 500, description = "Internal Server Error")

--- a/crates/server/src/api/routes/quests/get_quest.rs
+++ b/crates/server/src/api/routes/quests/get_quest.rs
@@ -15,7 +15,7 @@ pub struct GetQuestResponse {
 /// Returns the quest definition if the user is the creator of the quest (authentication required)
 #[utoipa::path(
     params(
-        ("quest_id" = String, description = "Quest ID")
+        ("quest_id" = String, description = "Quest UUID")
     ),
     responses(
         (status = 200, description = "Quest definition", body = GetQuestResponse),

--- a/crates/server/src/api/routes/quests/get_quest_reward.rs
+++ b/crates/server/src/api/routes/quests/get_quest_reward.rs
@@ -31,7 +31,7 @@ pub struct GetQuestRewardsParams {
 /// Returns the quest rewards
 #[utoipa::path(
     params(
-        ("quest_id" = String, description = "ID of the Quest")
+        ("quest_id" = String, description = "Quest UUID")
     ),
     responses(
         (status = 200, description = "Quest Rewards", body = GetQuestRewardResponse),

--- a/crates/server/src/api/routes/quests/get_quest_stats.rs
+++ b/crates/server/src/api/routes/quests/get_quest_stats.rs
@@ -21,7 +21,7 @@ pub struct GetQuestStatsResponse {
 /// Get a quest stats
 #[utoipa::path(
     params(
-        ("quest_id" = String, description = "Quest ID")
+        ("quest_id" = String, description = "Quest UUID")
     ),
     responses(
         (status = 200, description = "Quest Stats", body = GetQuestStatsResponse),

--- a/crates/server/src/api/routes/quests/get_quest_updates.rs
+++ b/crates/server/src/api/routes/quests/get_quest_updates.rs
@@ -14,7 +14,7 @@ pub struct GetQuestUpdatesResponse {
 /// Returns the IDs of the old quests
 #[utoipa::path(
     params(
-        ("quest_id" = String, description = "Quest ID")
+        ("quest_id" = String, description = "Quest UUID")
     ),
     responses(
         (status = 200, description = "IDs of the old quests", body = GetQuestUpdatesResponse),

--- a/crates/server/src/api/routes/quests/update_quest.rs
+++ b/crates/server/src/api/routes/quests/update_quest.rs
@@ -26,7 +26,7 @@ pub struct UpdateQuestResponse {
 #[utoipa::path(
     request_body = UpdateQuestRequest,
     params(
-        ("quest_id" = String, Path, description = "Quest ID")
+        ("quest_id" = String, Path, description = "Quest UUID")
     ),
     responses(
         (status = 200, description = "Quest updated", body = UpdateQuestResponse),

--- a/crates/server/tests/create_quest.rs
+++ b/crates/server/tests/create_quest.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 #[actix_web::test]
 async fn create_quest_should_be_200_without_reward() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -73,7 +73,7 @@ async fn create_quest_should_be_200_without_reward() {
 
 #[actix_web::test]
 async fn create_quest_should_be_200_with_reward() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -143,7 +143,7 @@ async fn create_quest_should_be_200_with_reward() {
 
 #[actix_web::test]
 async fn create_quest_should_be_400_quest_validation_error_missing_definition() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
@@ -185,7 +185,7 @@ async fn create_quest_should_be_400_quest_validation_error_missing_definition() 
 
 #[actix_web::test]
 async fn create_quest_should_be_400_quest_validation_error_rewards_webhook() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let Quest {
         name,
@@ -240,7 +240,7 @@ async fn create_quest_should_be_400_quest_validation_error_rewards_webhook() {
 
 #[actix_web::test]
 async fn create_quest_should_be_400_quest_validation_error_rewards_items() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let Quest {
         name,
@@ -356,7 +356,7 @@ async fn create_quest_should_be_400_quest_validation_error_rewards_items() {
 
 #[actix_web::test]
 async fn create_quest_should_be_401() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),

--- a/crates/server/tests/deactivate_quest.rs
+++ b/crates/server/tests/deactivate_quest.rs
@@ -10,7 +10,7 @@ use quests_server::api::routes::ErrorResponse;
 
 #[actix_web::test]
 async fn deactivate_quest_should_be_200() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -62,7 +62,7 @@ async fn deactivate_quest_should_be_200() {
 
 #[actix_web::test]
 async fn delete_quest_should_be_400() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
 
     let headers = get_signed_headers(create_test_identity(), "delete", "/api/quests/1aab", "{}");
 
@@ -86,7 +86,7 @@ async fn delete_quest_should_be_400() {
 
 #[actix_web::test]
 async fn delete_quest_should_be_401() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let req = TestRequest::delete().uri("/api/quests/1aab").to_request();
 
@@ -97,7 +97,7 @@ async fn delete_quest_should_be_401() {
 
 #[actix_web::test]
 async fn deactivate_quest_should_be_403() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();

--- a/crates/server/tests/get_instance_state.rs
+++ b/crates/server/tests/get_instance_state.rs
@@ -9,7 +9,7 @@ use quests_server::api::routes::quest_instances::GetInstanceStateResponse;
 
 #[actix_web::test]
 async fn get_instance_state_should_be_200() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -55,7 +55,7 @@ async fn get_instance_state_should_be_200() {
 
 #[actix_web::test]
 async fn get_instance_state_should_be_403() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();

--- a/crates/server/tests/get_quest.rs
+++ b/crates/server/tests/get_quest.rs
@@ -10,7 +10,7 @@ use quests_server::api::routes::ErrorResponse;
 
 #[actix_web::test]
 async fn get_quest_with_defintiions_should_be_200() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -80,7 +80,7 @@ async fn get_quest_with_defintiions_should_be_200() {
 
 #[actix_web::test]
 async fn get_quest_without_defintiions_should_be_200() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -120,7 +120,7 @@ async fn get_quest_without_defintiions_should_be_200() {
 
 #[actix_web::test]
 async fn get_quest_should_be_400() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let req = TestRequest::get().uri("/api/quests/1aaa").to_request();
 
@@ -134,7 +134,7 @@ async fn get_quest_should_be_400() {
 
 #[actix_web::test]
 async fn get_quest_should_be_404() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let id = uuid::Uuid::new_v4().to_string();
 

--- a/crates/server/tests/get_quest_rewards.rs
+++ b/crates/server/tests/get_quest_rewards.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 #[actix_web::test]
 async fn get_quest_rewards_should_be_200() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -69,7 +69,7 @@ async fn get_quest_rewards_should_be_200() {
 
 #[actix_web::test]
 async fn quest_has_no_rewards() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();

--- a/crates/server/tests/get_quest_stats.rs
+++ b/crates/server/tests/get_quest_stats.rs
@@ -11,7 +11,7 @@ use quests_server::api::routes::quests::GetQuestStatsResponse;
 
 #[actix_web::test]
 async fn get_quest_stats_should_be_200() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -74,7 +74,7 @@ async fn get_quest_stats_should_be_200() {
 
 #[actix_web::test]
 async fn get_quest_stats_should_be_403() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -126,7 +126,7 @@ async fn get_quest_stats_should_be_403() {
 
 #[actix_web::test]
 async fn get_quest_stats_should_be_401() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();

--- a/crates/server/tests/get_quests.rs
+++ b/crates/server/tests/get_quests.rs
@@ -10,7 +10,7 @@ use quests_server::api::routes::{quests::GetQuestsResponse, ErrorResponse};
 
 #[actix_web::test]
 async fn get_quests_should_be_200() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
@@ -39,12 +39,13 @@ async fn get_quests_should_be_200() {
     let body: GetQuestsResponse = read_body_json(response).await;
 
     assert_eq!(body.quests.len(), 1);
+    assert_eq!(body.total, 1);
     assert_eq!(body.quests[0].name, quest_definition.name)
 }
 
 #[actix_web::test]
 async fn get_quests_should_be_400() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let req = TestRequest::get()
         .uri("/api/quests?offset=0aa")

--- a/crates/server/tests/remove_event_from_instance.rs
+++ b/crates/server/tests/remove_event_from_instance.rs
@@ -1,0 +1,174 @@
+mod common;
+use actix_web::http::StatusCode;
+use actix_web::test::{call_service, init_service, TestRequest};
+pub use common::*;
+use quests_db::core::definitions::{AddEvent, CreateQuest, QuestsDatabase};
+use quests_db::create_quests_db_component;
+use quests_protocol::definitions::*;
+use uuid::Uuid;
+
+#[actix_web::test]
+async fn remove_event_from_instance_should_be_200() {
+    let config = get_configuration(None).await;
+    let db = create_quests_db_component(&config.database_url, true)
+        .await
+        .unwrap();
+
+    let app = init_service(build_app(&config).await).await;
+    let quest = quest_samples::grab_some_apples();
+
+    let create_quest = CreateQuest {
+        name: &quest.name,
+        description: &quest.description,
+        image_url: &quest.image_url,
+        definition: quest.definition.as_ref().unwrap().encode_to_vec(),
+        reward: None,
+    };
+
+    let id = db
+        .create_quest(&create_quest, "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5")
+        .await
+        .unwrap();
+
+    let quest_instance_id = db.start_quest(&id, "0xA").await.unwrap();
+
+    let event_id = Uuid::new_v4().to_string();
+    db.add_event(
+        &AddEvent {
+            id: event_id.clone(),
+            user_address: "0xA",
+            event: vec![],
+        },
+        &quest_instance_id,
+    )
+    .await
+    .unwrap();
+
+    let path = format!("/api/instances/{}/events/{}", quest_instance_id, event_id);
+
+    let headers = get_signed_headers(create_test_identity(), "delete", &path, "");
+
+    let req = TestRequest::delete()
+        .uri(&path)
+        .append_header(headers[0].clone())
+        .append_header(headers[1].clone())
+        .append_header(headers[2].clone())
+        .append_header(headers[3].clone())
+        .append_header(headers[4].clone())
+        .to_request();
+
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status().as_u16(), StatusCode::NO_CONTENT);
+}
+
+#[actix_web::test]
+async fn remove_event_from_instance_should_be_403() {
+    let config = get_configuration(None).await;
+    let db = create_quests_db_component(&config.database_url, true)
+        .await
+        .unwrap();
+
+    let app = init_service(build_app(&config).await).await;
+    let quest = quest_samples::grab_some_apples();
+
+    let create_quest = CreateQuest {
+        name: &quest.name,
+        description: &quest.description,
+        image_url: &quest.image_url,
+        definition: quest.definition.as_ref().unwrap().encode_to_vec(),
+        reward: None,
+    };
+
+    let id = db
+        .create_quest(&create_quest, "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1ba5")
+        .await
+        .unwrap();
+
+    let quest_instance_id = db.start_quest(&id, "0xA").await.unwrap();
+
+    let path = format!(
+        "/api/instances/{}/events/{}",
+        quest_instance_id,
+        Uuid::new_v4()
+    );
+
+    let headers = get_signed_headers(create_test_identity(), "delete", &path, "");
+
+    let req = TestRequest::delete()
+        .uri(&path)
+        .append_header(headers[0].clone())
+        .append_header(headers[1].clone())
+        .append_header(headers[2].clone())
+        .append_header(headers[3].clone())
+        .append_header(headers[4].clone())
+        .to_request();
+
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status().as_u16(), StatusCode::FORBIDDEN);
+}
+
+#[actix_web::test]
+async fn remove_event_from_instance_should_be_404() {
+    let config = get_configuration(None).await;
+    let db = create_quests_db_component(&config.database_url, true)
+        .await
+        .unwrap();
+
+    let app = init_service(build_app(&config).await).await;
+    let quest = quest_samples::grab_some_apples();
+
+    let create_quest = CreateQuest {
+        name: &quest.name,
+        description: &quest.description,
+        image_url: &quest.image_url,
+        definition: quest.definition.as_ref().unwrap().encode_to_vec(),
+        reward: None,
+    };
+
+    let id = db
+        .create_quest(&create_quest, "0x7949f9f239d1a0816ce5eb364a1f588ae9cc1bf5")
+        .await
+        .unwrap();
+
+    let path = format!(
+        "/api/instances/{}/events/{}",
+        Uuid::new_v4(),
+        Uuid::new_v4()
+    );
+
+    let headers = get_signed_headers(create_test_identity(), "delete", &path, "");
+
+    let req = TestRequest::delete()
+        .uri(&path)
+        .append_header(headers[0].clone())
+        .append_header(headers[1].clone())
+        .append_header(headers[2].clone())
+        .append_header(headers[3].clone())
+        .append_header(headers[4].clone())
+        .to_request();
+
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status().as_u16(), StatusCode::NOT_FOUND);
+
+    let quest_instance_id = db.start_quest(&id, "0xA").await.unwrap();
+
+    let path = format!(
+        "/api/instances/{}/events/{}",
+        quest_instance_id,
+        Uuid::new_v4()
+    );
+
+    let headers = get_signed_headers(create_test_identity(), "delete", &path, "");
+
+    let req = TestRequest::delete()
+        .uri(&path)
+        .append_header(headers[0].clone())
+        .append_header(headers[1].clone())
+        .append_header(headers[2].clone())
+        .append_header(headers[3].clone())
+        .append_header(headers[4].clone())
+        .to_request();
+
+    let response = call_service(&app, req).await;
+    assert_eq!(response.status().as_u16(), StatusCode::NOT_FOUND);
+}

--- a/crates/server/tests/update_quest.rs
+++ b/crates/server/tests/update_quest.rs
@@ -11,7 +11,7 @@ use quests_server::api::routes::ErrorResponse;
 
 #[actix_web::test]
 async fn update_quest_should_be_200() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();
@@ -124,7 +124,7 @@ async fn update_quest_should_be_200() {
 
 #[actix_web::test]
 async fn update_quest_should_be_400_uuid_bad_format() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
@@ -210,7 +210,7 @@ async fn update_quest_should_be_400_uuid_bad_format() {
 
 #[actix_web::test]
 async fn update_quest_should_be_400_quest_validation_error() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
     let quest_definition = CreateQuestRequest {
         name: "QUEST-1".to_string(),
@@ -261,7 +261,7 @@ async fn update_quest_should_be_400_quest_validation_error() {
 
 #[actix_web::test]
 async fn update_quest_should_be_401() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let app = init_service(build_app(&config).await).await;
 
     let quest_update = CreateQuestRequest {
@@ -330,7 +330,7 @@ async fn update_quest_should_be_401() {
 
 #[actix_web::test]
 async fn update_quest_should_be_403() {
-    let config = get_configuration().await;
+    let config = get_configuration(None).await;
     let db = create_quests_db_component(&config.database_url, true)
         .await
         .unwrap();

--- a/crates/system/tests/event_processing.rs
+++ b/crates/system/tests/event_processing.rs
@@ -1,3 +1,4 @@
+mod common;
 use crate::common::database::create_test_db;
 use quests_db::{core::definitions::*, create_quests_db_component};
 use quests_message_broker::messages_queue::MessagesQueue;
@@ -12,8 +13,6 @@ use wiremock::{
     matchers::{body_json, method, path},
     Mock, MockServer, ResponseTemplate,
 };
-
-mod common;
 
 #[tokio::test]
 async fn can_process_events() {
@@ -98,6 +97,7 @@ async fn can_process_events() {
     let quest_instance_id = result.unwrap();
 
     let mut config = Config::new().expect("Can parse config");
+    config.redis_url = "127.0.0.1:6379/2".to_string();
     config.database_url = db_url;
     let event_processor = EventProcessor::from_config(&config)
         .await
@@ -221,7 +221,7 @@ async fn should_call_rewards_hook_when_user_completes_a_quest() {
     let quest_instance_id = db.start_quest(&quest_id, user_address).await.unwrap();
 
     let mut config = Config::new().expect("Can parse config");
-    config.redis_url = "127.0.0.1:6379/2".to_string();
+    config.redis_url = "127.0.0.1:6379/3".to_string();
     config.database_url = db_url;
     let event_processor = EventProcessor::from_config(&config)
         .await


### PR DESCRIPTION
This PR: 
- adds endpoints for creators to handle Quest Instances state
- fixes db error namings
- fixes paginated endpoints to return the total items